### PR TITLE
fix(lively-scene): keep collecting after the reload a claim triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.11.1 - Lively Scene collects more than one reward again
+
+Lively Scene **Collect all** claimed one reward, reloaded the page and stopped
+there. The automation had to be restarted for every further reward, and the
+manual button had to be pressed again after every reload (issue #1857, reported
+by Gargoso).
+
+One reward per loaded page is how the game works: closing the reward popup
+reloads the page, and the sweep has to be picked up again afterwards. Nothing
+did that. Collecting ran from the event parser, and the event parser reaches
+the page only when the automation pipeline visits it or when *Event* automation
+is switched on -- off in the reported profile. Collecting now also starts from
+the code that draws the *Collect all* button, which runs on every Lively Scene
+page load, the same way Path of Attraction resumes its own sweep.
+
+The pipeline stayed away as well: the parser booked the next visit an hour
+ahead before the first reward was claimed, and the event had 19 minutes left. A
+claim now puts the event back in front of the parser, so the pipeline returns
+and finishes the sweep even when another task takes it away in between. Only a
+claim that happened does this, so the number of extra visits cannot exceed the
+number of rewards. The parser also no longer schedules a visit beyond the end
+of the event.
+
 ### v8.11.0 - One field for which boosters to buy, and how many
 
 Buying boosters used to need two settings that had to agree with each other:

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.11.0
+// @version      8.11.1
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -21345,6 +21345,42 @@ function fmtSignedPct(value) {
     return (value > 0 ? '+' : '') + value.toFixed(1) + 'pp';
 }
 
+;// ./src/Module/Events/EventRegistry.ts
+// EventRegistry.ts -- write access to the event registry (Temp_eventsList).
+//
+// The registry is the list handleEventParsing walks to pick the next event
+// page to visit: one entry per event id, carrying next_refresh among other
+// fields. EventModule owns filling it; the operations an individual event
+// module needs live here instead, because EventModule imports those modules
+// and the reverse import would be a new cycle (ARCH-001).
+//
+// Depends on: StorageHelper.ts, HHStoredVars.ts, StorageKeys.ts
+// Used by: EventModule.ts, LivelyScene.ts
+//
+
+
+
+/**
+ * Mark one event as due for a re-read (#1843).
+ *
+ * handleEventParsing picks up any event whose next_refresh has passed, so
+ * setting it to zero is enough to have the pipeline visit the event page on
+ * its next pass -- no extra navigation.
+ *
+ * A no-op for an event that is not in the registry: the entry is created by
+ * parseEventPage, and an id that is not there yet gets visited anyway
+ * (getEventIDsToVisit).
+ */
+function markEventStale(eventId) {
+    if (!eventId)
+        return;
+    const list = getStoredJSON(HHStoredVarPrefixKey + TK.eventsList, {});
+    if (!list || !list[eventId])
+        return;
+    list[eventId]["next_refresh"] = 0;
+    setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(list));
+}
+
 ;// ./src/Module/Events/LivelyScene.pure.ts
 // LivelyScene.pure.ts -- Pure decision logic for the Lively Scene event.
 //
@@ -21427,9 +21463,12 @@ var LivelyScene_awaiter = (undefined && undefined.__awaiter) || function (thisAr
 // scenes to earn rewards. This module tracks scene progression, manages
 // event energy, and collects available rewards automatically.
 //
-// Depends on: LivelyScene.pure.ts (piece selection), RewardHelper, PageNavigationService
-// Used by: EventModule.ts (called when Lively Scene event is active)
+// Depends on: LivelyScene.pure.ts (piece selection), RewardHelper, EventRegistry.ts
+// Used by: EventModule.ts (parse), AutoLoopPageHandlers.ts (run, on every
+//          event-page load)
 //
+
+
 
 
 
@@ -21447,12 +21486,12 @@ class LivelyScene {
     }
     static parse(hhEvent, eventList, hhEventData) {
         const eventID = hhEvent.eventId;
-        const refreshTimer = randomInterval(3600, 4000);
-        const timeLeft = $('#contains_all #events .nc-panel .timer span[rel="expires"]').text();
-        let remainingTime = 3600;
-        if (timeLeft !== undefined && timeLeft.length) {
-            remainingTime = Number(convertTimeToInt(timeLeft));
-        }
+        const remainingTime = LivelyScene.readRemainingTime();
+        // An event that ends before its own next_refresh is never looked at
+        // again: pruneExpiredEvents drops the entry as expired first. Keep the
+        // next visit inside the event, so rewards that unlock in the last hour
+        // are still reachable (#1857).
+        const refreshTimer = Math.min(randomInterval(3600, 4000), Math.max(Math.floor(remainingTime / 2), 60));
         setTimer('eventLivelySceneGoing', remainingTime);
         eventList[eventID] = {};
         eventList[eventID]["id"] = eventID;
@@ -21471,6 +21510,47 @@ class LivelyScene {
         if (shouldTrigger) {
             LivelyScene.goAndCollect(remainingTime, manualCollectAll);
         }
+    }
+    /**
+     * Seconds left on the event, read from the page.
+     *
+     * 3600 when the timer is not on the page -- the value parse() has always
+     * defaulted to. Note that this is fail-open for the end-of-event sweep
+     * (3600 is below every collectAllTimer setting); it is kept as it was
+     * because no measurement says the element can be missing here.
+     */
+    static readRemainingTime() {
+        const timeLeft = $('#contains_all #events .nc-panel .timer span[rel="expires"]').text();
+        if (timeLeft === undefined || !timeLeft.length)
+            return 3600;
+        return Number(convertTimeToInt(timeLeft));
+    }
+    /**
+     * Pick the sweep up again on every event-page load.
+     *
+     * A claim ends in closeRewardPopupIfAny, which reloads the page, so one
+     * loaded DOM yields at most one reward. Continuing therefore has to happen
+     * after the reload -- and parse() cannot do it: it runs only when the
+     * pipeline visits the event page (handleEventParsing) or when plusEvent is
+     * on, because AutoLoopPageHandlers gates parseEventPage on that setting.
+     * run() runs on every event-page load, which is where Path of Attraction
+     * resumes its own sweep as well (#1816, #1857).
+     */
+    static collectOnPageLoad() {
+        return LivelyScene_awaiter(this, void 0, void 0, function* () {
+            const manualCollectAll = getStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll) === 'true';
+            const remainingTime = LivelyScene.readRemainingTime();
+            const shouldTrigger = decideCollectTrigger({
+                autoCollect: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true",
+                manualCollectAll,
+                autoCollectAll: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll) === "true",
+                remainingTime,
+                limitBeforeEnd: getLimitTimeBeforeEnd(),
+            });
+            if (shouldTrigger) {
+                yield LivelyScene.goAndCollect(remainingTime, manualCollectAll);
+            }
+        });
     }
     static parseClaimableRewards(remainingTime, manualCollectAll = false) {
         const puzzlePieces = getHHVars('current_event.event_data.puzzle_pieces');
@@ -21497,6 +21577,16 @@ class LivelyScene {
     }
     static goAndCollect(remainingTime_1) {
         return LivelyScene_awaiter(this, arguments, void 0, function* (remainingTime, manualCollectAll = false) {
+            // parse() and run() can both fire on the same page load -- the
+            // pipeline parses the event page the page handler has just drawn --
+            // and two sweeps would click the same puzzle pieces. The flag lives
+            // for one page load; the reload after a claim clears it.
+            if (LivelyScene.collecting) {
+                logHHAuto("LivelyScene collect already running on this page.");
+                return false;
+            }
+            LivelyScene.collecting = true;
+            let claimed = false;
             try {
                 const rewards = LivelyScene.parseClaimableRewards(remainingTime, manualCollectAll);
                 if (manualCollectAll)
@@ -21515,6 +21605,15 @@ class LivelyScene {
                             if (currentCollectButton.length > 0) {
                                 currentCollectButton.trigger('click');
                                 yield TimeHelper.sleep(randomInterval(400, 700));
+                                // Closing the popup reloads the page, so this DOM
+                                // yields no second claim. parse() has just booked
+                                // the event for an hour from now, which is what
+                                // kept the pipeline from coming back to finish the
+                                // sweep (#1857). Only on a claim that happened, so
+                                // the extra visits stay bounded by the number of
+                                // pieces and cannot become a reload loop (#1738).
+                                markEventStale(queryStringGetParam(window.location.search, 'tab') || '');
+                                claimed = true;
                                 RewardHelper.closeRewardPopupIfAny(); // refresh;
                                 yield TimeHelper.sleep(randomInterval(400, 700));
                                 return true;
@@ -21533,6 +21632,12 @@ class LivelyScene {
                 const message = err instanceof Error ? err.message : String(err);
                 logHHAuto(`ERROR during collect LivelyScene rewards: ${message}`);
                 setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'false');
+            }
+            finally {
+                // After a claim the flag stays set: this DOM is spent, and the
+                // reload that the popup close starts clears it.
+                if (!claimed)
+                    LivelyScene.collecting = false;
             }
             return false;
         });
@@ -21555,26 +21660,29 @@ class LivelyScene {
         });
     }
     static run() {
-        var _a, _b;
-        LivelyScene.displayCollectAllButton();
-        if (getStoredValue(HHStoredVarPrefixKey + SK.showRewardsRecap) === "true") {
-            const puzzlePieces = getHHVars('current_event.event_data.puzzle_pieces');
-            if (puzzlePieces.length > 0) {
-                for (let currentReward = 0; currentReward < puzzlePieces.length; currentReward++) {
-                    const puzzlePiece = puzzlePieces[currentReward];
-                    if (puzzlePiece.reward_unlocked && !puzzlePiece.reward_claimed) {
-                        const rewardType = ((_a = puzzlePiece === null || puzzlePiece === void 0 ? void 0 : puzzlePiece.reward) === null || _a === void 0 ? void 0 : _a.shards) ? 'girl_shards' : (_b = puzzlePiece === null || puzzlePiece === void 0 ? void 0 : puzzlePiece.reward) === null || _b === void 0 ? void 0 : _b.rewards[0].type;
-                        const $puzzlePiece = $(`#puzzle_template #puzzle_piece_${puzzlePiece.id_piece}.claimable`);
-                        const iconHref = RewardHelper.getRewardsIconHref(rewardType);
-                        if ($puzzlePiece.length > 0 && iconHref) {
-                            const image = LivelyScene._makeSVGImage($puzzlePiece, iconHref);
-                            document.getElementById(`puzzle_piece_${puzzlePiece.id_piece}`).appendChild(image);
-                            logHHAuto(`Add icon for ${rewardType} to #puzzle_piece_${puzzlePiece.id_piece}`);
+        return LivelyScene_awaiter(this, void 0, void 0, function* () {
+            var _a, _b;
+            LivelyScene.displayCollectAllButton();
+            if (getStoredValue(HHStoredVarPrefixKey + SK.showRewardsRecap) === "true") {
+                const puzzlePieces = getHHVars('current_event.event_data.puzzle_pieces');
+                if (puzzlePieces.length > 0) {
+                    for (let currentReward = 0; currentReward < puzzlePieces.length; currentReward++) {
+                        const puzzlePiece = puzzlePieces[currentReward];
+                        if (puzzlePiece.reward_unlocked && !puzzlePiece.reward_claimed) {
+                            const rewardType = ((_a = puzzlePiece === null || puzzlePiece === void 0 ? void 0 : puzzlePiece.reward) === null || _a === void 0 ? void 0 : _a.shards) ? 'girl_shards' : (_b = puzzlePiece === null || puzzlePiece === void 0 ? void 0 : puzzlePiece.reward) === null || _b === void 0 ? void 0 : _b.rewards[0].type;
+                            const $puzzlePiece = $(`#puzzle_template #puzzle_piece_${puzzlePiece.id_piece}.claimable`);
+                            const iconHref = RewardHelper.getRewardsIconHref(rewardType);
+                            if ($puzzlePiece.length > 0 && iconHref) {
+                                const image = LivelyScene._makeSVGImage($puzzlePiece, iconHref);
+                                document.getElementById(`puzzle_piece_${puzzlePiece.id_piece}`).appendChild(image);
+                                logHHAuto(`Add icon for ${rewardType} to #puzzle_piece_${puzzlePiece.id_piece}`);
+                            }
                         }
                     }
                 }
             }
-        }
+            yield LivelyScene.collectOnPageLoad();
+        });
     }
     static hasUnclaimedRewards() {
         return $(".puzzle_piece.claimable:visible").length > 0;
@@ -21591,6 +21699,8 @@ class LivelyScene {
         }
     }
 }
+/** One collect sweep at a time per page load, see goAndCollect. */
+LivelyScene.collecting = false;
 
 ;// ./src/Module/Events/PathOfAttraction.ts
 var PathOfAttraction_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -28016,6 +28126,7 @@ var EventModule_awaiter = (undefined && undefined.__awaiter) || function (thisAr
 
 
 
+
 class EventModule {
     /**
      * Remove stale event data from sessionStorage for the given event ID.
@@ -28325,21 +28436,12 @@ class EventModule {
         return getStoredJSON(HHStoredVarPrefixKey + TK.eventGirl, {});
     }
     /**
-     * Mark one event as due for a re-read (#1843).
-     *
-     * handleEventParsing picks up any event whose next_refresh has passed, so
-     * setting it to zero is enough to have the pipeline visit the event page on
-     * its next pass -- no extra navigation, and no effect on anyone who is not
-     * in the skin phase.
+     * Mark one event as due for a re-read (#1843). The registry write itself
+     * lives in EventRegistry.ts so LivelyScene can reach it without importing
+     * this module, which imports LivelyScene.
      */
     static markEventStale(eventId) {
-        if (!eventId)
-            return;
-        const list = getStoredJSON(HHStoredVarPrefixKey + TK.eventsList, {});
-        if (!list || !list[eventId])
-            return;
-        list[eventId]["next_refresh"] = 0;
-        setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(list));
+        markEventStale(eventId);
     }
     static getEventMythicGirl() {
         return getStoredJSON(HHStoredVarPrefixKey + TK.eventMythicGirl, {});

--- a/docs-internal/live-verification-lessons.md
+++ b/docs-internal/live-verification-lessons.md
@@ -206,11 +206,29 @@ without it collecting. Used this way in the #1846 verification: the run logged
 `Going to get {"tier":3,...}` and two intercepted clicks, and the reward stayed
 where it was.
 
+**Pin `Temp_scriptversion` to the bundle you inject.** Two builds in one run
+means the version changes on every switch, and `StartService.checkVersion` then
+calls `debugDeleteTempVars()` -- which wipes exactly the Temp vars a case just
+wrote, `Temp_lseManualCollectAll` and `Temp_eventsList` among them. Write the
+injected bundle's `@version` into `HHAuto_Temp_scriptversion` with the rest of
+the case setup and the wipe never fires.
+
+**A gate in shared code can be measured on another page.** The `plusEvent`
+switch in front of `parseEventPage` sits in `AutoLoopPageHandlers`, not in an
+event module, so it was measurable on a running Star Orgies event while no
+Lively Scene event existed (#1857): setting off, no `parsed` attribute on
+`#contains_all #events`; setting on, `parsed=true`, on both builds. What does
+*not* transfer that way is anything the event module itself reads -- its
+selectors, its collect path. Name which of the two a measurement covered.
+
 `~/.config/hhauto-claude/tools/live-collect-verify.js` does this out of the
 box: it opens a visible window, waits for the login, then runs a list of cases
 against two builds on the same live page with the click interception in place,
 and reports per case whether the collection gate was entered and whether a
-reward was touched. Both verdicts are derived from the console output rather
+reward was touched. `lse-collect-verify.js` beside it is the same idea for the
+Lively Scene page: it looks the event tab up itself and falls back to the
+shared-code measurement above (`FALLBACK_TAB`) when no such event runs.
+Both verdicts are derived from the console output rather
 than from page variables, so a navigation mid-run does not silently produce an
 empty result -- it is reported instead. Bundles, page URL and the containers to
 block are environment variables; build the comparison bundle with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.11.0",
+      "version": "8.11.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Events/LivelyScene.spec.ts
+++ b/spec/Module/Events/LivelyScene.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * LivelyScene.spec.ts -- issue #1857.
+ *
+ * Reported: automatic and manual "Collect all" claim one reward, the page
+ * reloads, and nothing continues. Measured in the reporter's 8.11.0 log
+ * (2026-09-01, lively_scene_event_14 on Nutaku):
+ *
+ *   5:40:13.612  run(): icons for pieces 2,3,5,8,11,14,15,26   (8 open)
+ *   5:40:14.619  "On going lively scene event."                (parse, from
+ *                 handleEventParsing -- the only caller with plusEvent off)
+ *   5:40:14.628  handleEventParsing ev=done                    (collect still
+ *                 running: parse does not await goAndCollect)
+ *   5:40:15.630  reward popup closed                           -> reload
+ *   5:40:17.807  run(): icons for 3,5,8,11,14,15,26            (7 open)
+ *                 and no "On going lively scene event." at all
+ *   5:40:18.815  the pipeline navigates to the missions page
+ *
+ * Two causes behind that, both covered here:
+ *
+ *  1. Only parse() ever reached goAndCollect, and parse() runs from
+ *     parseEventPage -- which AutoLoopPageHandlers calls only when plusEvent
+ *     or plusEventMythic is on (both "false" in the reported profile), so
+ *     after the reload nobody picked the sweep up. run(), which does run on
+ *     every event-page load, only drew the button and the icons. It now
+ *     continues the sweep, the way PathOfAttraction.run() does (#1816).
+ *
+ *  2. parse() books next_refresh 3600-4000 s ahead before collecting, and
+ *     handleEventParsing selects on next_refresh alone, so the pipeline did
+ *     not come back to the page either -- the event ended 19 minutes later.
+ *     A claim now marks the event stale again, and the refresh delay stays
+ *     inside the event.
+ *
+ * Fixture note: in the game the side-panel collect button becomes claimable
+ * only after the puzzle piece is clicked. jsdom does not run the game's
+ * handlers, so the button is rendered claimable from the start; the click on
+ * the piece is still made and is what the claim path needs to find.
+ */
+import { LivelyScene } from "../../../src/Module/Events/LivelyScene";
+import { ConfigHelper } from "../../../src/Helper/ConfigHelper";
+import { TimeHelper } from "../../../src/Helper/TimeHelper";
+import { RewardHelper } from "../../../src/Helper/RewardHelper";
+import { Timers } from "../../../src/Helper/TimerHelper";
+import { HHStoredVarPrefixKey } from "../../../src/config/HHStoredVars";
+import { SK, TK } from "../../../src/config/StorageKeys";
+import { HHEvent, HHEventData, HHEventList } from "../../../src/model/HHEvent";
+import { KKPuzzlePieces } from "../../../src/model/KK/KKPuzzlePieces";
+import { MockHelper } from "../../testHelpers/MockHelpers";
+
+jest.mock("../../../src/Service/PageNavigationService", () => ({
+    gotoPage: jest.fn().mockReturnValue(true),
+    safeReload: jest.fn(),
+    safeNavigateHref: jest.fn(),
+    addNutakuSession: jest.fn((x: unknown) => x),
+}));
+
+jest.mock("../../../src/Service/AutoLoop", () => ({
+    autoLoop: jest.fn(),
+}));
+
+const EVENT_PAGE = ConfigHelper.getHHScriptVars("pagesIDEvent");
+const EVENT_ID = "lively_scene_event_14";
+
+/** One claimable piece, shaped like the entries in the reported log. */
+function piece(idPiece: number, opts: { unlocked?: boolean; claimed?: boolean; type?: string } = {}): KKPuzzlePieces {
+    return {
+        id_piece: idPiece,
+        id_objective: 1,
+        reward: { loot: true, rewards: [{ type: opts.type ?? "energy_fight", value: "4" }] },
+        reward_unlocked: opts.unlocked ?? true,
+        reward_claimed: opts.claimed ?? false,
+        objective: { id_objective: 1, identifier: "spend_nrj", name: "Spend energy", anchors: {} },
+        current_points: 150,
+        target_points: 150,
+    } as unknown as KKPuzzlePieces;
+}
+
+/**
+ * The part of the event page the module reads: the panel timer, one puzzle
+ * piece per entry, and the side panel with the collect button.
+ */
+function renderLivelyScenePage(pieces: KKPuzzlePieces[], timerText: string) {
+    const svg = pieces
+        .map((p) => `<g id="puzzle_piece_${p.id_piece}" class="puzzle_piece ${p.reward_claimed ? "claimed" : "claimable"}"><image x="10" y="20"/></g>`)
+        .join("");
+    document.body.innerHTML = `<div id="hh_hentai" page="${EVENT_PAGE}">
+        <div id="contains_all">
+            <div id="events">
+                <div class="nc-panel"><div class="timer"><span rel="expires">${timerText}</span></div></div>
+                <div id="lse_content">
+                    <div id="puzzle_template">${svg}</div>
+                    <div class="lse_side_panel"><button class="purple_button_L claimable">Collect</button></div>
+                </div>
+            </div>
+        </div>
+    </div>`;
+    (unsafeWindow as any).current_event = { event_data: { puzzle_pieces: pieces } };
+}
+
+function setSetting(key: string, value: string) {
+    localStorage.setItem(HHStoredVarPrefixKey + key, value);
+}
+
+/** The registry entry handleEventParsing selects on. */
+function seedRegistry(nextRefreshInMs: number) {
+    sessionStorage.setItem(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify({
+        [EVENT_ID]: {
+            id: EVENT_ID,
+            type: "livelyscene",
+            seconds_before_end: Date.now() + 20 * 60 * 1000,
+            next_refresh: Date.now() + nextRefreshInMs,
+            isCompleted: false,
+        },
+    }));
+}
+
+function registryEntry(): Record<string, any> {
+    return JSON.parse(sessionStorage.getItem(HHStoredVarPrefixKey + TK.eventsList) || "{}")[EVENT_ID];
+}
+
+const livelySceneEvent = {
+    eventTypeKnown: true,
+    eventId: EVENT_ID,
+    eventType: "livelyscene",
+    isLivelyScene: true,
+    isEnabled: true,
+} as HHEvent;
+
+describe("LivelyScene -- #1857", () => {
+    let restoreLocation: () => void;
+    let claimSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        for (const name of Object.keys(Timers)) delete Timers[name];
+        LivelyScene.collecting = false;
+        restoreLocation = MockHelper.snapshotLocation();
+        MockHelper.mockDomain("www.hentaiheroes.com", "event.html", `tab=${EVENT_ID}`);
+        jest.spyOn(TimeHelper, "sleep").mockResolvedValue(undefined as never);
+        // Closing the reward popup is the step that reloads the page: it marks
+        // "a reward was claimed" without driving a real claim.
+        claimSpy = jest.spyOn(RewardHelper, "closeRewardPopupIfAny").mockImplementation(() => undefined as never);
+        setSetting(SK.showRewardsRecap, "false");
+        setSetting(SK.collectAllTimer, "12");
+        setSetting(SK.autoLivelySceneEventCollect, "false");
+        setSetting(SK.autoLivelySceneEventCollectAll, "false");
+        setSetting(SK.autoLivelySceneEventCollectablesList, "null");
+        setSetting(TK.lseManualCollectAll, "false");
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        delete (unsafeWindow as any).current_event;
+        restoreLocation();
+        jest.restoreAllMocks();
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    const claimed = () => claimSpy.mock.calls.length;
+
+    describe("continuing after the reload", () => {
+        it("collects on a plain event-page load when the end-of-event sweep is due", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "19m 47s");
+            setSetting(SK.autoLivelySceneEventCollectAll, "true");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(1);
+        });
+
+        it("resumes a manual sweep from the stored flag, with every setting off", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "19m 47s");
+            setSetting(TK.lseManualCollectAll, "true");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(1);
+        });
+
+        it("collects nothing on a page load when no collect mode is on", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "19m 47s");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(0);
+        });
+
+        it("leaves the sweep closed while the event is outside the final window", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "5h 0m");
+            setSetting(SK.autoLivelySceneEventCollectAll, "true");
+            setSetting(SK.collectAllTimer, "1");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(0);
+        });
+
+        it("claims once when parse() and run() both fire on the same page load", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "19m 47s");
+            setSetting(SK.autoLivelySceneEventCollectAll, "true");
+            const eventList: HHEventList = {};
+
+            const both = LivelyScene.run();
+            LivelyScene.parse(livelySceneEvent, eventList, {} as HHEventData);
+            await both;
+
+            expect(claimed()).toBe(1);
+        });
+    });
+
+    describe("bringing the pipeline back", () => {
+        it("marks the event stale after a claim, so handleEventParsing returns", async () => {
+            renderLivelyScenePage([piece(2), piece(3)], "19m 47s");
+            seedRegistry(3600 * 1000);
+            setSetting(SK.autoLivelySceneEventCollectAll, "true");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(1);
+            expect(registryEntry().next_refresh).toBe(0);
+        });
+
+        it("leaves the registry alone when nothing was claimed", async () => {
+            renderLivelyScenePage([piece(2, { claimed: true })], "19m 47s");
+            seedRegistry(3600 * 1000);
+            setSetting(SK.autoLivelySceneEventCollectAll, "true");
+
+            await LivelyScene.run();
+
+            expect(claimed()).toBe(0);
+            expect(registryEntry().next_refresh).toBeGreaterThan(Date.now());
+        });
+
+        it("keeps the next refresh inside an event that ends within the hour", () => {
+            renderLivelyScenePage([piece(2)], "19m 47s");
+            const eventList: HHEventList = {};
+
+            LivelyScene.parse(livelySceneEvent, eventList, {} as HHEventData);
+
+            const entry = eventList[EVENT_ID] as Record<string, number>;
+            const refreshInS = (entry["next_refresh"] - Date.now()) / 1000;
+            const endInS = (entry["seconds_before_end"] - Date.now()) / 1000;
+            expect(refreshInS).toBeLessThan(endInS);
+            expect(refreshInS).toBeGreaterThan(0);
+        });
+
+        it("keeps the hourly refresh for a long-running event", () => {
+            renderLivelyScenePage([piece(2)], "2d 5h 30m");
+            const eventList: HHEventList = {};
+
+            LivelyScene.parse(livelySceneEvent, eventList, {} as HHEventData);
+
+            const entry = eventList[EVENT_ID] as Record<string, number>;
+            const refreshInS = (entry["next_refresh"] - Date.now()) / 1000;
+            expect(refreshInS).toBeGreaterThanOrEqual(3600);
+            expect(refreshInS).toBeLessThanOrEqual(4000);
+        });
+    });
+});

--- a/src/Module/Events/EventModule.ts
+++ b/src/Module/Events/EventModule.ts
@@ -14,6 +14,7 @@ import { KKEventGirl } from "../../model/KK/KKEventGirl";
 import { BossBang } from "./BossBang";
 import { CumbackContests } from "./CumbackContests";
 import { DoublePenetration } from "./DoublePenetration";
+import { markEventStale as markStaleInRegistry } from "./EventRegistry";
 import { KinkyCumpetition } from "./KinkyCumpetition";
 import { LivelyScene } from "./LivelyScene";
 import { MythicEvent } from "./MythicEvent";
@@ -399,19 +400,12 @@ export class EventModule {
     }
 
     /**
-     * Mark one event as due for a re-read (#1843).
-     *
-     * handleEventParsing picks up any event whose next_refresh has passed, so
-     * setting it to zero is enough to have the pipeline visit the event page on
-     * its next pass -- no extra navigation, and no effect on anyone who is not
-     * in the skin phase.
+     * Mark one event as due for a re-read (#1843). The registry write itself
+     * lives in EventRegistry.ts so LivelyScene can reach it without importing
+     * this module, which imports LivelyScene.
      */
     static markEventStale(eventId: string): void {
-        if (!eventId) return;
-        const list = getStoredJSON<Record<string, any>>(HHStoredVarPrefixKey + TK.eventsList, {});
-        if (!list || !list[eventId]) return;
-        list[eventId]["next_refresh"] = 0;
-        setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(list));
+        markStaleInRegistry(eventId);
     }
 
     static getEventMythicGirl(): EventGirl{

--- a/src/Module/Events/EventRegistry.ts
+++ b/src/Module/Events/EventRegistry.ts
@@ -1,0 +1,33 @@
+// EventRegistry.ts -- write access to the event registry (Temp_eventsList).
+//
+// The registry is the list handleEventParsing walks to pick the next event
+// page to visit: one entry per event id, carrying next_refresh among other
+// fields. EventModule owns filling it; the operations an individual event
+// module needs live here instead, because EventModule imports those modules
+// and the reverse import would be a new cycle (ARCH-001).
+//
+// Depends on: StorageHelper.ts, HHStoredVars.ts, StorageKeys.ts
+// Used by: EventModule.ts, LivelyScene.ts
+//
+import { getStoredJSON, setStoredValue } from "../../Helper/StorageHelper";
+import { HHStoredVarPrefixKey } from "../../config/HHStoredVars";
+import { TK } from "../../config/StorageKeys";
+
+/**
+ * Mark one event as due for a re-read (#1843).
+ *
+ * handleEventParsing picks up any event whose next_refresh has passed, so
+ * setting it to zero is enough to have the pipeline visit the event page on
+ * its next pass -- no extra navigation.
+ *
+ * A no-op for an event that is not in the registry: the entry is created by
+ * parseEventPage, and an id that is not there yet gets visited anyway
+ * (getEventIDsToVisit).
+ */
+export function markEventStale(eventId: string): void {
+    if (!eventId) return;
+    const list = getStoredJSON<Record<string, any>>(HHStoredVarPrefixKey + TK.eventsList, {});
+    if (!list || !list[eventId]) return;
+    list[eventId]["next_refresh"] = 0;
+    setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(list));
+}

--- a/src/Module/Events/LivelyScene.ts
+++ b/src/Module/Events/LivelyScene.ts
@@ -4,8 +4,9 @@
 // scenes to earn rewards. This module tracks scene progression, manages
 // event energy, and collects available rewards automatically.
 //
-// Depends on: LivelyScene.pure.ts (piece selection), RewardHelper, PageNavigationService
-// Used by: EventModule.ts (called when Lively Scene event is active)
+// Depends on: LivelyScene.pure.ts (piece selection), RewardHelper, EventRegistry.ts
+// Used by: EventModule.ts (parse), AutoLoopPageHandlers.ts (run, on every
+//          event-page load)
 //
 import { ConfigHelper } from "../../Helper/ConfigHelper";
 import { getHHVars } from "../../Helper/HHHelper";
@@ -20,8 +21,10 @@ import { logHHAuto } from "../../Utils/LogUtils";
 import { isJSON } from "../../Utils/Utils";
 import { HHStoredVarPrefixKey } from "../../config/HHStoredVars";
 import { SK, TK } from "../../config/StorageKeys";
+import { queryStringGetParam } from "../../Helper/UrlHelper";
 import { HHEvent, HHEventData, HHEventList } from "../../model/HHEvent";
 import { KKPuzzlePieces } from "../../model/KK/KKPuzzlePieces";
+import { markEventStale } from "./EventRegistry";
 import {
     PuzzlePieceLite,
     decideCollectTrigger,
@@ -30,19 +33,21 @@ import {
 
 export class LivelyScene {
 
+    /** One collect sweep at a time per page load, see goAndCollect. */
+    static collecting = false;
+
     static isEnabled() {
         return ConfigHelper.getHHScriptVars("isEnabledLivelySceneEvent", false); // And 10 girls 3*
     }
 
     static parse(hhEvent: HHEvent, eventList: HHEventList, hhEventData: HHEventData) {
         const eventID = hhEvent.eventId;
-        const refreshTimer = randomInterval(3600, 4000);
-
-        const timeLeft = $('#contains_all #events .nc-panel .timer span[rel="expires"]').text();
-        let remainingTime = 3600;
-        if (timeLeft !== undefined && timeLeft.length) {
-            remainingTime = Number(convertTimeToInt(timeLeft));
-        }
+        const remainingTime = LivelyScene.readRemainingTime();
+        // An event that ends before its own next_refresh is never looked at
+        // again: pruneExpiredEvents drops the entry as expired first. Keep the
+        // next visit inside the event, so rewards that unlock in the last hour
+        // are still reachable (#1857).
+        const refreshTimer = Math.min(randomInterval(3600, 4000), Math.max(Math.floor(remainingTime / 2), 60));
         setTimer('eventLivelySceneGoing', remainingTime);
 
         eventList[eventID] = {};
@@ -65,6 +70,46 @@ export class LivelyScene {
             LivelyScene.goAndCollect(remainingTime, manualCollectAll);
         }
 
+    }
+
+    /**
+     * Seconds left on the event, read from the page.
+     *
+     * 3600 when the timer is not on the page -- the value parse() has always
+     * defaulted to. Note that this is fail-open for the end-of-event sweep
+     * (3600 is below every collectAllTimer setting); it is kept as it was
+     * because no measurement says the element can be missing here.
+     */
+    static readRemainingTime(): number {
+        const timeLeft = $('#contains_all #events .nc-panel .timer span[rel="expires"]').text();
+        if (timeLeft === undefined || !timeLeft.length) return 3600;
+        return Number(convertTimeToInt(timeLeft));
+    }
+
+    /**
+     * Pick the sweep up again on every event-page load.
+     *
+     * A claim ends in closeRewardPopupIfAny, which reloads the page, so one
+     * loaded DOM yields at most one reward. Continuing therefore has to happen
+     * after the reload -- and parse() cannot do it: it runs only when the
+     * pipeline visits the event page (handleEventParsing) or when plusEvent is
+     * on, because AutoLoopPageHandlers gates parseEventPage on that setting.
+     * run() runs on every event-page load, which is where Path of Attraction
+     * resumes its own sweep as well (#1816, #1857).
+     */
+    static async collectOnPageLoad() {
+        const manualCollectAll = getStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll) === 'true';
+        const remainingTime = LivelyScene.readRemainingTime();
+        const shouldTrigger = decideCollectTrigger({
+            autoCollect: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true",
+            manualCollectAll,
+            autoCollectAll: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll) === "true",
+            remainingTime,
+            limitBeforeEnd: getLimitTimeBeforeEnd(),
+        });
+        if (shouldTrigger) {
+            await LivelyScene.goAndCollect(remainingTime, manualCollectAll);
+        }
     }
 
     static parseClaimableRewards(remainingTime: number, manualCollectAll = false) {
@@ -93,6 +138,16 @@ export class LivelyScene {
 
     static async goAndCollect(remainingTime: number, manualCollectAll = false)
     {
+        // parse() and run() can both fire on the same page load -- the
+        // pipeline parses the event page the page handler has just drawn --
+        // and two sweeps would click the same puzzle pieces. The flag lives
+        // for one page load; the reload after a claim clears it.
+        if (LivelyScene.collecting) {
+            logHHAuto("LivelyScene collect already running on this page.");
+            return false;
+        }
+        LivelyScene.collecting = true;
+        let claimed = false;
         try {
             const rewards = LivelyScene.parseClaimableRewards(remainingTime, manualCollectAll);
             if (manualCollectAll) setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'true');
@@ -114,6 +169,15 @@ export class LivelyScene {
                         if (currentCollectButton.length > 0) {
                             currentCollectButton.trigger('click');
                             await TimeHelper.sleep(randomInterval(400, 700));
+                            // Closing the popup reloads the page, so this DOM
+                            // yields no second claim. parse() has just booked
+                            // the event for an hour from now, which is what
+                            // kept the pipeline from coming back to finish the
+                            // sweep (#1857). Only on a claim that happened, so
+                            // the extra visits stay bounded by the number of
+                            // pieces and cannot become a reload loop (#1738).
+                            markEventStale(queryStringGetParam(window.location.search, 'tab') || '');
+                            claimed = true;
                             RewardHelper.closeRewardPopupIfAny() // refresh;
                             await TimeHelper.sleep(randomInterval(400, 700));
                             return true;
@@ -132,6 +196,10 @@ export class LivelyScene {
             const message = err instanceof Error ? err.message : String(err);
             logHHAuto(`ERROR during collect LivelyScene rewards: ${message}`);
             setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'false');
+        } finally {
+            // After a claim the flag stays set: this DOM is spent, and the
+            // reload that the popup close starts clears it.
+            if (!claimed) LivelyScene.collecting = false;
         }
         return false;
     }
@@ -154,7 +222,7 @@ export class LivelyScene {
         });
     }
 
-    static run(){
+    static async run(){
         LivelyScene.displayCollectAllButton();
 
         if (getStoredValue(HHStoredVarPrefixKey + SK.showRewardsRecap) === "true") {
@@ -179,6 +247,8 @@ export class LivelyScene {
                 }
             }
         }
+
+        await LivelyScene.collectOnPageLoad();
     }
 
     static hasUnclaimedRewards(): boolean {


### PR DESCRIPTION
Lively Scene **Collect all** claimed one reward, the page reloaded, and nothing
continued — the automation had to be restarted for every further reward, and the
manual button pressed again after every reload. Issue #1857, reported by Gargoso.

## Cause

One reward per loaded DOM is inherent: closing the reward popup reloads the page.
The sweep therefore has to be resumed afterwards, and nothing did that.

`goAndCollect` was reachable only from `parse()`, and `parse()` runs only when the
pipeline visits the event page or when *Event* automation is on — `AutoLoopPageHandlers`
gates `parseEventPage` on that setting, and it was off in the reported profile.
Measured in the reporter's log: after the reload at 5:40:16 `run()` drew the icons,
no parse followed, and 4 s later the pipeline navigated to the missions page.

The pipeline stayed away as well: `parse()` booked `next_refresh` an hour ahead
before the first claim, `getStaleEventIDs` selects on `next_refresh` alone, and the
event had 19 minutes left.

## Change

- `run()` resumes the sweep on every event-page load, the way `PathOfAttraction.run()`
  does. A flag keeps it to one sweep per loaded DOM, since both entry points can fire
  on the same load; the reload after a claim clears it.
- A claim marks the event stale again, so the pipeline returns and finishes the sweep.
  Only a claim that happened does this, which bounds the extra visits by the number of
  pieces and keeps it from becoming a reload loop (#1738).
- The refresh delay stays inside the event, so rewards unlocking in the last hour are
  still reachable.
- The registry write moved to a leaf module: `LivelyScene` importing `EventModule`
  would be a new cycle, `EventModule` already imports `LivelyScene`.

## Verification

- Nine new tests. Five fail on 8.11.0, the four negative controls hold in both
  directions.
- The `plusEvent` gate was measured against the live game on a running event page,
  both directions and both builds: setting off, no `parsed` attribute; setting on,
  `parsed=true`.
- **Not** verified live: the Lively Scene page itself — no such event was running.
  A run with a real claim across reloads is still open for the next one.

## Left alone

- `parse()` still starts `goAndCollect()` without awaiting it, so the block reports
  done while the claim runs. That shape is shared by every event parser.
- `readRemainingTime()` still returns 3600 when the timer is missing, which is
  fail-open for the collect-all branch. Named in the code, not changed: no measurement
  says the element can be missing there.

Version 8.11.1, CHANGELOG updated, built userscript in the same commit.