### PR TITLE
chore: gate real player identifiers out of the repository

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Die Commit-Nachricht ist der zweite Weg nach draußen -- sie steht im Repo und
+# in jedem Klon, und die Datei-Prüfung sieht sie nicht.
+node scripts/check-player-data.mjs --message "$1" || exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Blockiert Commits, die eine echte Spielerkennung tragen.
+#
+# Das ist die einzige Schicht, die wirklich verhindert statt zu entdecken:
+# hier ist noch nichts auf GitHub. Der CI-Schritt darunter ist das Netz für
+# --no-verify und für andere Rechner, auf denen dieser Hook nicht eingerichtet
+# ist (Einrichtung: npm run hooks:install).
+node scripts/check-player-data.mjs --staged || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,11 @@ jobs:
       - name: Used by / Depends on headers match the imports (blocking)
         run: npm run check:headers
 
+      # Net under the pre-commit hook: it only guards the machine it is
+      # installed on, and --no-verify walks past it.
+      - name: No real player identifiers in the tree (blocking)
+        run: npm run check:player-data
+
       - name: Knip dead exports (advisory)
         continue-on-error: true
         run: npm run deps:dead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,29 @@ npm run deps:circular:check  # Zyklen gegen die eingefrorene Baseline
 npm run check:gm-grants  # GM-Grants gegen die tatsächliche Nutzung
 npm run check:docs       # storage-keys.md und page-mapping.md gegen den Code
 npm run check:headers    # Used by / Depends on gegen die echten Importe
+npm run check:player-data # keine echten Spielerkennungen im Baum
 npm run build            # HHAuto.user.js gehört in denselben Commit
 ```
 
-Die letzten beiden gibt es, weil beides schon auseinandergelaufen ist:
-`storage-keys.md` stand einmal neun Keys hinter dem Code, und 17 Dateiköpfe
+`check:docs` und `check:headers` gibt es, weil beides schon auseinandergelaufen
+ist: `storage-keys.md` stand einmal neun Keys hinter dem Code, und 17 Dateiköpfe
 nannten Module, die die Datei nicht mehr importieren.
+
+## Mitschnitte tragen keine echten Spieler
+
+Fixtures und Messnotizen werden **beim Aufnehmen** anonymisiert: eigenes Konto
+`1`, fremde Spieler `1000` aufwärts, Namen `Player_N`. Eine Kontonummer gehört
+auch nicht in eine Commit-Nachricht, einen PR-Text oder einen Messbericht.
+
+Das ist zweimal schiefgegangen und war nur durch einen History-Rewrite eines
+öffentlichen Repos wieder herauszubekommen -- mitsamt Force-Push, 879
+betroffenen PR-Refs und einem Support-Ticket. `check:player-data` prüft es,
+und der Pre-Commit-Hook hält es auf, bevor etwas GitHub erreicht. Den Hook auf
+einem neuen Klon einmal einrichten:
+
+```
+npm run hooks:install    # setzt core.hooksPath auf .githooks
+```
 
 ## Live gegen das Spiel messen
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "bundle:stats": "webpack --config webpack.config.js --profile --json > stats.json",
     "bundle:analyze": "webpack-bundle-analyzer stats.json",
     "check:docs": "node scripts/check-doc-drift.mjs",
-    "check:headers": "node scripts/check-module-headers.mjs"
+    "check:headers": "node scripts/check-module-headers.mjs",
+    "check:player-data": "node scripts/check-player-data.mjs",
+    "hooks:install": "git config core.hooksPath .githooks"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-player-data.mjs
+++ b/scripts/check-player-data.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Prüft, dass keine echten Spielerkennungen im Repository landen.
+//
+// Warum: zweimal ist genau das passiert -- mitgeschnittenes Spiel-JSON wurde
+// als Fixture committet und eine Messnotiz nannte das Konto, auf dem gemessen
+// wurde. Beides stand danach in einem öffentlichen Repo und war nur noch
+// durch einen History-Rewrite herauszubekommen.
+//
+// Eine Kontonummer ist eine Zahl; von einer beliebigen Zahl lässt sich nicht
+// beweisen, dass sie keine ist. Prüfbar ist die Form, in der solche Daten
+// hereinkommen: die Schlüssel des Spiel-JSON und die Prosa der Messnotizen.
+// Diese Datei enthält deshalb keine einzige echte Kennung -- sie prüft
+// Schlüssel, nicht Werte.
+//
+// Regel: Fixtures tragen nur Platzhalter-Identitäten. Das eigene Konto ist 1,
+// fremde Spieler sind 1000 aufwärts, Namen sind Player_N. Genau so lagen
+// hero-armor.json und die Nicknames schon vorher.
+//
+// Aufruf:
+//   node scripts/check-player-data.mjs            # alle getrackten Dateien
+//   node scripts/check-player-data.mjs --staged   # nur der Commit-Inhalt (Hook)
+//   node scripts/check-player-data.mjs --message <datei>   # Commit-Nachricht
+//
+// Exit: 0 sauber, 1 Fund, 2 interner Fehler.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const staged = process.argv.includes('--staged');
+// Die Nachricht ist der zweite Weg nach draußen: sie steht im Repo, in der
+// Release-Übersicht und in jedem Klon, und keine Datei-Prüfung sieht sie.
+const messageFile = process.argv.includes('--message')
+    ? process.argv[process.argv.indexOf('--message') + 1]
+    : null;
+
+// Erlaubte Platzhalter: 1 für das eigene Konto, 1000-1999 für fremde Spieler.
+const idIsPlaceholder = (n) => n === 1 || (n >= 1000 && n <= 1999);
+const nickIsPlaceholder = (s) => /^Player_\d+$/.test(s);
+
+// Schlüssel, die eine Person benennen. Quoted wie im JSON und unquoted wie in
+// einem TS-Objektliteral; der Wert muss eine Zahl sein, damit `girl.id_member`
+// im Code nicht anschlägt.
+const ID_KEYS = ['id_member', 'id_player', 'member_id', 'id_user', 'id_hero'];
+const idPattern = new RegExp(`"?(${ID_KEYS.join('|')})"?\\s*:\\s*(\\d+)`, 'g');
+const nickPattern = /"?nicknames?"?\s*:\s*"([^"]*)"/g;
+// Messnotizen: "Account 12345", "Konto 12345", "account id 12345" -- die Form,
+// in der die Kennung in die Dokumentation kam. Die Zahl muss direkt am Wort
+// hängen: "Klein-Account-Test (kein 2400-girls-Konto)" in ADR-003 meint eine
+// Mädchenzahl und ist kein Fund.
+const prosePattern = /\b(account|konto)\b(?:[ -]?(?:id|nr\.?|#))?[\s:#-]{0,3}(\d{4,})\b/gi;
+
+// Binärdateien und alles, was ohnehin nur generiert ist, bleiben draußen;
+// HHAuto.user.js NICHT -- der gebaute Stand ist die Auslieferung, und die
+// Kennung stand beim letzten Mal auch darin.
+const SKIP = /^(coverage\/|node_modules\/|.*\.(png|jpg|jpeg|gif|webp|ico|zip|pdf|woff2?)$)/;
+
+function git(args) {
+    // stderr geschluckt: contentOf fragt auch nach Pfaden, die es im Index noch
+    // nicht gibt, und deren Meldung ist keine für den Benutzer.
+    return execFileSync('git', args, {
+        encoding: 'utf8', maxBuffer: 512 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+}
+
+function fileList() {
+    const out = staged
+        ? git(['diff', '--cached', '--name-only', '--diff-filter=ACMR'])
+        : git(['ls-files']);
+    return out.split('\n').filter((f) => f && !SKIP.test(f));
+}
+
+function contentOf(path) {
+    try {
+        // Im Hook den Index lesen, nicht den Arbeitsbaum: was im Index steht,
+        // ist das, was der Commit trägt. Im vollen Lauf die Platte, damit auch
+        // eine gerade erst hinzugefügte Datei geprüft wird.
+        return staged ? git(['show', `:${path}`]) : readFileSync(path, 'utf8');
+    } catch {
+        return null; // gelöscht, oder nicht lesbar
+    }
+}
+
+function lineOf(text, index) {
+    return text.slice(0, index).split('\n').length;
+}
+
+const findings = [];
+
+function scan(label, text, prose) {
+    for (const m of text.matchAll(idPattern)) {
+        if (!idIsPlaceholder(Number(m[2]))) {
+            findings.push([label, lineOf(text, m.index), `${m[1]} ist keine Platzhalter-Kennung (erlaubt: 1 oder 1000-1999)`]);
+        }
+    }
+    for (const m of text.matchAll(nickPattern)) {
+        if (!nickIsPlaceholder(m[1])) {
+            findings.push([label, lineOf(text, m.index), `nickname "${m[1]}" ist kein Platzhalter (erlaubt: Player_N)`]);
+        }
+    }
+    if (prose) {
+        for (const m of text.matchAll(prosePattern)) {
+            findings.push([label, lineOf(text, m.index), `nennt eine Kontonummer ("${m[0].trim()}")`]);
+        }
+    }
+}
+
+if (messageFile) {
+    scan('Commit-Nachricht', readFileSync(messageFile, 'utf8'), true);
+} else for (const file of fileList()) {
+    const text = contentOf(file);
+    if (text === null || text.includes('\0')) continue;
+    scan(file, text, file.endsWith('.md'));
+}
+
+if (findings.length > 0) {
+    for (const [file, line, why] of findings) {
+        console.error(`FUND  ${file}:${line}  ${why}`);
+    }
+    console.error(`\n${findings.length} Fund(e). Mitschnitte werden beim Aufnehmen anonymisiert:`);
+    console.error('eigenes Konto -> 1, fremde Spieler -> 1000 aufwärts, Namen -> Player_N.');
+    console.error('Der Wert gehört auch nicht in die Commit-Nachricht oder den PR-Text.');
+    process.exit(1);
+}
+
+const scope = messageFile ? 'in der Commit-Nachricht' : staged ? 'im Commit' : 'in den getrackten Dateien';
+console.log(`OK    keine echten Spielerkennungen ${scope}`);


### PR DESCRIPTION
Twice a real account identifier reached this public repository: once as the raw
`id_member` of captured game JSON in four fixtures, once as the account named in
two measurement notes. Getting it back out took a history rewrite of 387 commits,
a force-push, 879 affected pull request refs and a support ticket — and the old
objects stay served until GitHub purges them.

## What is checkable

An account id is a number, and no check can prove of an arbitrary number that it
is not one. What *is* checkable is the shape such data arrives in: the keys of
captured game JSON, and the prose of a measurement note.

So the rule is the one parts of the tree already followed — fixtures carry
placeholder identities: own account `1`, other players `1000` upwards, names
`Player_N` — and the check enforces it. The checker contains no identifier
itself; it looks at keys, not values.

## Three layers, in order of effect

| Layer | Acts | Prevents or detects |
|---|---|---|
| `.githooks/pre-commit` | before the commit | **prevents** — nothing has reached GitHub yet |
| `.githooks/commit-msg` | before the commit | **prevents** — the message no file check sees |
| `npm run check:player-data` | in the ordinary gate run | prevents, if the gates are run |
| CI step | after the push | detects — the net under `--no-verify` and other machines |

Hooks are installed once per clone with `npm run hooks:install`.

## Verified in both directions

- A fixture with a real id and an unpseudonymised nickname is refused; `1001` and
  `Player_7` in the same file are not.
- A commit message naming an account number is refused; an ordinary one is not.
  This branch's own message was refused on the first attempt for quoting the test
  value.
- The girl count in the small-account note in ADR-003 does not trip it: the number
  has to hang directly on the word.
- The hook was exercised end to end: the offending commit did not move `HEAD`, the
  clean one did.

## Not covered

Screenshots, attached logs, issue and PR text. And `--no-verify` walks past both
hooks, which is what the CI step is for.