### PR TITLE
fix(booster): stop wiping a Mythic Slot list longer than five codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.11.2 - Mythic Slot keeps a list longer than five codes
+
+The *Mythic Slot* field accepted `MB2;MB3;...;MB12`, but the list was gone the
+next time the menu was opened (issue #1865, reported by Zary).
+
+Two regexes described the field, and only one of them had been widened when
+the list was allowed to name all twelve boosters. The field's own pattern took
+up to twelve codes; the check that runs against the stored value on every page
+load still capped at five, found the longer list invalid and reset the setting
+to its default. The debug log said so in as many words: `HHStoredVar
+HHAuto_Setting_autoEquipMythicBooster is invalid, reseting.`
+
+Both now read the same definition, kept in one place next to the parser that
+consumes it. Nothing caps the list: it is a preference order -- "take whichever
+of these I happen to own" -- while the game's five mythic slots are a different
+number, and the walk down the list stops when no slot is free.
+
+A list that was wiped is not recoverable; it has to be entered once more.
+
 ### v8.11.1 - Lively Scene collects more than one reward again
 
 Lively Scene **Collect all** claimed one reward, reloaded the page and stopped

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.11.1
+// @version      8.11.2
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -2165,6 +2165,42 @@ function manageTranslationPopUp() {
     }
 }
 
+;// ./src/Module/Booster.pure.ts
+// Booster.pure.ts -- syntax of the "Mythic Slot" priority list.
+//
+// Pure: no DOM, no storage, no imports. The impure half lives in Booster.ts.
+//
+// The one definition of what may stand in that field, so the menu's pattern
+// attribute, the isValid check setDefaults runs against the stored value on
+// every page load, and the runtime parser cannot state different rules. They
+// did: the field was widened to all twelve codes while isValid kept a cap of
+// five, so a longer list was accepted, saved, and then wiped on the next load
+// (issue #1865). The same lesson had already been written down for the buy
+// list in Market.pure.ts (#1844).
+//
+// The list is a preference order, not a slot assignment -- "take whichever of
+// these I happen to own". Its length and Booster.MYTHIC_SLOT_COUNT are two
+// different numbers, so the syntax caps nothing; the walk down the list stops
+// when no slot is free.
+//
+// Used by: config/InputPattern.ts, config/HHStoredVars.ts, Module/Booster.ts
+//
+/** One mythic booster code, MB1..MB12. MB1 is the Sandalwood perfume. */
+const MYTHIC_CODE = "MB(?:[1-9]|1[0-2])";
+/**
+ * Written without anchors because that is what an HTML `pattern` attribute
+ * expects; every other caller anchors it itself.
+ *
+ * Whitespace around a code is tolerated because the parser trims before it
+ * compares -- an entry the parser reads must not paint the field red. An empty
+ * value is valid and means "off".
+ */
+const MYTHIC_LIST_PATTERN = "(?:\\s*" + MYTHIC_CODE + "\\s*(?:;\\s*" + MYTHIC_CODE + "\\s*)*)?";
+/** Anchored form, for checking a whole stored value. */
+const MYTHIC_LIST_RE = new RegExp("^" + MYTHIC_LIST_PATTERN + "$");
+/** Anchored form of a single code, for checking one entry of a split list. */
+const MYTHIC_CODE_RE = new RegExp("^" + MYTHIC_CODE + "$");
+
 ;// ./src/config/StorageKeys.ts
 /**
  * Prefix every HHauto key carries. It lives here, in the leaf module, and not
@@ -2764,6 +2800,10 @@ function getTimeLeft(name) {
 // Defines each variable's storage type (setting vs. temp), default value,
 // validation regex, UI label, and type. Used by the settings menu and storage layer.
 
+// A dependency-free leaf, so this stays within ADR-008 rule 2 ("extract shared
+// constants into dependency-free leaf modules") and adds no import cycle --
+// unlike the PlaceOfPower edge the note below describes.
+
 
 
 
@@ -2874,7 +2914,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster] =
         setMenu: true,
         menuType: "value",
         kobanUsing: false,
-        isValid: /^(\s*(MB[1-9]|MB1[0-2])\s*(;\s*(MB[1-9]|MB1[0-2])\s*){0,4})?$/
+        isValid: MYTHIC_LIST_RE
     };
 HHStoredVars[HHStoredVarPrefixKey + SK.autoChamps] =
     {
@@ -8253,6 +8293,7 @@ function migrateSavedDefaults(defaults, filterKey, maxKey) {
 // Each pattern constrains what the user can enter in a specific settings field
 // (e.g., timers, thresholds, booster filters).
 
+
 const thousandsSeparator = (11111).toLocaleString().replace(/1+/g, '');
 const HHAuto_inputPattern = {
     nWith1000sSeparator: "[0-9" + thousandsSeparator + "]+",
@@ -8264,7 +8305,10 @@ const HHAuto_inputPattern = {
     // Gem Detector could never be entered (#1844).
     autoBuyBoostersFilter: BUY_LIST_PATTERN,
     autoEquipBoostersSlots: "B[1-4](;B[1-4]){0,3}",
-    autoEquipMythicBooster: "(\\s*(MB[1-9]|MB1[0-2])\\s*(;\\s*(MB[1-9]|MB1[0-2])\\s*){0,11})?",
+    // Same story as the buy list above: this field and the isValid check on
+    // the stored value had drifted to different lengths, so a list of more
+    // than five codes was wiped on the next load (#1865).
+    autoEquipMythicBooster: MYTHIC_LIST_PATTERN,
     //calculatePowerLimits:"(\-?[0-9]+;\-?[0-9]+)|default",
     mousePauseTimeout: "[0-9]+",
     safeSecondsForContest: "[0-9]+",
@@ -12150,6 +12194,7 @@ var Booster_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
 
 
 
+
 const DEFAULT_BOOSTERS = { normal: [], mythic: [] };
 /**
  * Manages booster tracking, auto-equip, and Sandalwood Perfume logic for event farming.
@@ -12715,7 +12760,7 @@ class Booster {
         const parsed = raw
             .split(";")
             .map((s) => s.trim().toUpperCase())
-            .filter((s) => /^MB([1-9]|1[0-2])$/.test(s));
+            .filter((s) => MYTHIC_CODE_RE.test(s));
         if (parsed.length === 0) {
             logHHAuto("Auto-equip mythic: no valid codes in '" + raw + "', treating as off.");
         }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -23344,8 +23344,7 @@ class Shop {
             // Debug: log each booster found in player inventory with id_item and quantity
             for (const [identifier, data] of Object.entries(BoosterIdMap)) {
                 const qty = HaveBooster[identifier] || 0;
-                const entry = data;
-                logHHAuto(`  Booster inventory: ${entry.name} [${identifier}] id_item=${entry.id_item} rarity=${entry.rarity} qty=${qty}`);
+                logHHAuto(`  Booster inventory: ${data.name} [${identifier}] id_item=${data.id_item} rarity=${data.rarity} qty=${qty}`);
             }
             setStoredValue(HHStoredVarPrefixKey + TK.storeContents, JSON.stringify([assA, assB, assG, assP]));
             setStoredValue(HHStoredVarPrefixKey + TK.charLevel, HeroHelper.getLevel());
@@ -23727,7 +23726,8 @@ class Shop {
             }
         }
         function checkAjaxComplete(event, request, settings) {
-            const match = settings.data.match(/action=market_get_armor&id_member_armor=(\d+)/);
+            const sentData = typeof settings.data === 'string' ? settings.data : '';
+            const match = sentData.match(/action=market_get_armor&id_member_armor=(\d+)/);
             if (match === null)
                 return;
             allLoaded = request.responseJSON.items.length === 0 && request.responseJSON.success; // No more to load
@@ -23877,7 +23877,7 @@ class Shop {
                         }
                         else {
                             const currentBest = arraysOfSets[indexType][sellableItemObj.subtype];
-                            const itemCarac = sellableItemObj[caracsOfSets[indexType]];
+                            const itemCarac = Number(sellableItemObj[caracsOfSets[indexType]]);
                             //checking best gear in inventory based on best class stat
                             if (currentBest[0] < itemCarac) {
                                 currentBest[0] = itemCarac;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.11.1",
+  "version": "8.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.11.1",
+      "version": "8.11.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "build": "webpack --config webpack.config.js",
     "lint": "eslint \"src/**/*.ts\" \"spec/**/*.ts\"",
-    "lint:ci": "eslint \"src/**/*.ts\" \"spec/**/*.ts\" --max-warnings 1046",
+    "lint:ci": "eslint \"src/**/*.ts\" \"spec/**/*.ts\" --max-warnings 1031",
     "typecheck": "tsc --noEmit",
     "deps:graph": "madge --extensions ts src",
     "deps:circular": "madge --circular --extensions ts src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.11.1",
+  "version": "8.11.2",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Booster.pure.spec.ts
+++ b/spec/Module/Booster.pure.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Booster.pure.spec.ts -- the "Mythic Slot" priority list, issue #1865.
+ *
+ * The bug under test: the field accepted up to twelve codes while the
+ * isValid check on the stored value still capped at five, so a longer list
+ * was saved and then wiped by setDefaults on the next page load. The list is
+ * a preference order, not a slot assignment -- its length and the five mythic
+ * slots are two different numbers -- so nothing here caps it.
+ */
+import { HHStoredVars, HHStoredVarPrefixKey } from "../../src/config/HHStoredVars";
+import { HHAuto_inputPattern } from "../../src/config/InputPattern";
+import { SK } from "../../src/config/StorageKeys";
+import { MYTHIC_CODE_RE, MYTHIC_LIST_PATTERN, MYTHIC_LIST_RE } from "../../src/Module/Booster.pure";
+
+const ALL_TWELVE = "MB1;MB2;MB3;MB4;MB5;MB6;MB7;MB8;MB9;MB10;MB11;MB12";
+/** What the reporter typed: everything but MB1, which the event owns. */
+const REPORTED = "MB2;MB3;MB4;MB5;MB6;MB7;MB8;MB9;MB10;MB11;MB12";
+
+const matchesField = (value: string) =>
+    new RegExp("^" + HHAuto_inputPattern.autoEquipMythicBooster + "$").test(value);
+const storedIsValid = (value: string) =>
+    HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster].isValid.test(value);
+
+describe("Mythic Slot list -- the field and the stored value agree", () => {
+    it.each([
+        ["", "empty means off"],
+        ["MB1", "a single code"],
+        ["MB1;MB2;MB5;MB8;MB12", "the five of the tooltip example"],
+        [REPORTED, "the eleven of issue #1865"],
+        [ALL_TWELVE, "all twelve"],
+        [" MB1 ; MB10 ", "whitespace the parser trims away"],
+    ])("accepts %s (%s) in both checks", (value) => {
+        expect(matchesField(value)).toBe(true);
+        expect(storedIsValid(value)).toBe(true);
+    });
+
+    it.each([
+        ["MB0", "there is no MB0"],
+        ["MB13", "there is no MB13"],
+        ["B1", "a legendary code belongs in the buy list"],
+        ["mb1", "the parser upper-cases, but the field never accepted lower case"],
+        ["MB1,MB2", "the separator is a semicolon"],
+        ["MB1;", "a trailing separator names no code"],
+    ])("rejects %s (%s) in both checks", (value) => {
+        expect(matchesField(value)).toBe(false);
+        expect(storedIsValid(value)).toBe(false);
+    });
+
+    it("is literally the same definition on both sides", () => {
+        expect(HHAuto_inputPattern.autoEquipMythicBooster).toBe(MYTHIC_LIST_PATTERN);
+        expect(HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster].isValid).toBe(MYTHIC_LIST_RE);
+    });
+
+    it("caps nothing, because the list is a priority order and not a slot count", () => {
+        const twentyFour = (ALL_TWELVE + ";" + ALL_TWELVE);
+        expect(matchesField(twentyFour)).toBe(true);
+        expect(storedIsValid(twentyFour)).toBe(true);
+    });
+});
+
+describe("Mythic Slot list -- a single code", () => {
+    it.each(["MB1", "MB9", "MB10", "MB12"])("accepts %s", (code) => {
+        expect(MYTHIC_CODE_RE.test(code)).toBe(true);
+    });
+
+    it.each(["MB0", "MB13", "MB1;MB2", "B4", ""])("rejects %s", (code) => {
+        expect(MYTHIC_CODE_RE.test(code)).toBe(false);
+    });
+});

--- a/src/Module/Booster.pure.ts
+++ b/src/Module/Booster.pure.ts
@@ -1,0 +1,39 @@
+// Booster.pure.ts -- syntax of the "Mythic Slot" priority list.
+//
+// Pure: no DOM, no storage, no imports. The impure half lives in Booster.ts.
+//
+// The one definition of what may stand in that field, so the menu's pattern
+// attribute, the isValid check setDefaults runs against the stored value on
+// every page load, and the runtime parser cannot state different rules. They
+// did: the field was widened to all twelve codes while isValid kept a cap of
+// five, so a longer list was accepted, saved, and then wiped on the next load
+// (issue #1865). The same lesson had already been written down for the buy
+// list in Market.pure.ts (#1844).
+//
+// The list is a preference order, not a slot assignment -- "take whichever of
+// these I happen to own". Its length and Booster.MYTHIC_SLOT_COUNT are two
+// different numbers, so the syntax caps nothing; the walk down the list stops
+// when no slot is free.
+//
+// Used by: config/InputPattern.ts, config/HHStoredVars.ts, Module/Booster.ts
+//
+
+/** One mythic booster code, MB1..MB12. MB1 is the Sandalwood perfume. */
+const MYTHIC_CODE = "MB(?:[1-9]|1[0-2])";
+
+/**
+ * Written without anchors because that is what an HTML `pattern` attribute
+ * expects; every other caller anchors it itself.
+ *
+ * Whitespace around a code is tolerated because the parser trims before it
+ * compares -- an entry the parser reads must not paint the field red. An empty
+ * value is valid and means "off".
+ */
+export const MYTHIC_LIST_PATTERN =
+    "(?:\\s*" + MYTHIC_CODE + "\\s*(?:;\\s*" + MYTHIC_CODE + "\\s*)*)?";
+
+/** Anchored form, for checking a whole stored value. */
+export const MYTHIC_LIST_RE = new RegExp("^" + MYTHIC_LIST_PATTERN + "$");
+
+/** Anchored form of a single code, for checking one entry of a split list. */
+export const MYTHIC_CODE_RE = new RegExp("^" + MYTHIC_CODE + "$");

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -11,6 +11,7 @@ import { HHStoredVarPrefixKey } from "../config/HHStoredVars";
 import { SK, TK } from "../config/StorageKeys";
 import { EventGirl } from '../model/EventGirl';
 import { LoveRaid } from '../model/LoveRaid';
+import { MYTHIC_CODE_RE } from "./Booster.pure";
 import { EventModule } from "./Events/EventModule";
 import { isSkinPhase, shardTotalAfterFight, ShardDrop } from "./Events/GirlSkins.pure";
 import { LoveRaidManager } from "./Events/LoveRaidManager";
@@ -639,7 +640,7 @@ export class Booster {
         const parsed = raw
             .split(";")
             .map((s: string) => s.trim().toUpperCase())
-            .filter((s: string) => /^MB([1-9]|1[0-2])$/.test(s));
+            .filter((s: string) => MYTHIC_CODE_RE.test(s));
         if (parsed.length === 0) {
             logHHAuto("Auto-equip mythic: no valid codes in '" + raw + "', treating as off.");
         }

--- a/src/Module/Shop.ts
+++ b/src/Module/Shop.ts
@@ -23,6 +23,26 @@ import { SK, TK } from "../config/StorageKeys";
 import { Booster } from "./Booster";
 import { decideCheckShop } from "./Shop.pure";
 
+// Shapes of the JSON the game puts into a slot's data-d attribute. Only the
+// fields this module reads are declared; the game ships more.
+interface ValueStackSlotData {
+    quantity: number;
+    item: { value: number };
+}
+interface BoosterSlotData {
+    quantity: number;
+    item: { identifier: string; id_item?: string | number; name: string; rarity: string };
+}
+// The carac fields are addressed by a name built at runtime ('carac' + class),
+// hence the open index signature next to the two fixed fields.
+type ArmorSlotData = { id_equip: string; subtype: number } & Record<string, unknown>;
+
+// Slot counts of the sell menu, keyed carac -> type -> rarity -> lock status.
+type ItemLockCounts = Record<string, number>;
+type ItemRarityCounts = Record<string, ItemLockCounts>;
+type ItemTypeCounts = Record<number, ItemRarityCounts>;
+type ItemCaracCounts = Record<string | number, ItemTypeCounts>;
+
 export class Shop {
 
     static isTimeToCheckShop() {
@@ -58,19 +78,19 @@ export class Shop {
             var assB:Record<string, unknown>[]=[];
             var assG:Record<string, unknown>[]=[];
             var assP:Record<string, unknown>[]=[];
-            $('#shops div.armor.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<any>(this.dataset.d,null);if(d)assA.push(d);}});
-            $('#shops div.booster.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<any>(this.dataset.d,null);if(d)assB.push(d);}});
-            $('#shops div.gift.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<any>(this.dataset.d,null);if(d)assG.push(d);}});
-            $('#shops div.potion.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<any>(this.dataset.d,null);if(d)assP.push(d);}});
+            $('#shops div.armor.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<Record<string, unknown> | null>(this.dataset.d,null);if(d)assA.push(d);}});
+            $('#shops div.booster.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<Record<string, unknown> | null>(this.dataset.d,null);if(d)assB.push(d);}});
+            $('#shops div.gift.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<Record<string, unknown> | null>(this.dataset.d,null);if(d)assG.push(d);}});
+            $('#shops div.potion.merchant-inventory-item .slot').each(function(){if (this.dataset.d){const d=safeJsonParse<Record<string, unknown> | null>(this.dataset.d,null);if(d)assP.push(d);}});
     
             var HaveAff=0;
             var HaveExp=0;
             var HaveBooster: Record<string, number>={};
-            $('#shops div.gift.player-inventory-content .slot').each(function(){if (this.dataset.d) { const d=safeJsonParse<any>(this.dataset.d,null); if(d)HaveAff+=d.quantity*d.item.value;}});
-            $('#shops div.potion.player-inventory-content .slot').each(function(){if (this.dataset.d) { const d=safeJsonParse<any>(this.dataset.d,null); if(d)HaveExp+=d.quantity*d.item.value;}});
+            $('#shops div.gift.player-inventory-content .slot').each(function(){if (this.dataset.d) { const d=safeJsonParse<ValueStackSlotData | null>(this.dataset.d,null); if(d)HaveAff+=d.quantity*d.item.value;}});
+            $('#shops div.potion.player-inventory-content .slot').each(function(){if (this.dataset.d) { const d=safeJsonParse<ValueStackSlotData | null>(this.dataset.d,null); if(d)HaveExp+=d.quantity*d.item.value;}});
     
             var BoosterIdMap: Record<string, { id_item: string; identifier: string; name: string; rarity: string }>={};
-            $('#shops div.booster.player-inventory-content .slot').each(function(){ if (this.dataset.d) { const d=safeJsonParse<any>(this.dataset.d,null); if(d){ HaveBooster[d.item.identifier] = d.quantity; if(d.item.id_item) BoosterIdMap[d.item.identifier] = { id_item: String(d.item.id_item), identifier: d.item.identifier, name: d.item.name, rarity: d.item.rarity };}}});
+            $('#shops div.booster.player-inventory-content .slot').each(function(){ if (this.dataset.d) { const d=safeJsonParse<BoosterSlotData | null>(this.dataset.d,null); if(d){ HaveBooster[d.item.identifier] = d.quantity; if(d.item.id_item) BoosterIdMap[d.item.identifier] = { id_item: String(d.item.id_item), identifier: d.item.identifier, name: d.item.name, rarity: d.item.rarity };}}});
     
             setStoredValue(HHStoredVarPrefixKey+TK.haveAff, HaveAff);
             setStoredValue(HHStoredVarPrefixKey+TK.haveExp, HaveExp);
@@ -81,8 +101,7 @@ export class Shop {
             // Debug: log each booster found in player inventory with id_item and quantity
             for (const [identifier, data] of Object.entries(BoosterIdMap)) {
                 const qty = HaveBooster[identifier] || 0;
-                const entry = data as any;
-                logHHAuto(`  Booster inventory: ${entry.name} [${identifier}] id_item=${entry.id_item} rarity=${entry.rarity} qty=${qty}`);
+                logHHAuto(`  Booster inventory: ${data.name} [${identifier}] id_item=${data.id_item} rarity=${data.rarity} qty=${qty}`);
             }
     
             setStoredValue(HHStoredVarPrefixKey+TK.storeContents, JSON.stringify([assA,assB,assG,assP]));
@@ -222,7 +241,7 @@ export class Shop {
                 itemsType.push(i);
             }
     
-            const itemsList: Record<string, any> = {};
+            const itemsList: ItemCaracCounts = {};
             for (const c of itemsCaracs)
             {
                 let filteredCarac;
@@ -553,8 +572,9 @@ export class Shop {
             }
         }
     
-        function checkAjaxComplete(event: any, request: any, settings: any){
-            const match = settings.data.match(/action=market_get_armor&id_member_armor=(\d+)/);
+        function checkAjaxComplete(event: JQuery.TriggeredEvent, request: JQuery.jqXHR, settings: JQuery.AjaxSettings){
+            const sentData = typeof settings.data === 'string' ? settings.data : '';
+            const match = sentData.match(/action=market_get_armor&id_member_armor=(\d+)/);
             if (match === null) return;
             allLoaded = request.responseJSON.items.length === 0 && request.responseJSON.success; // No more to load
             if (fetchStarted)
@@ -712,7 +732,7 @@ export class Shop {
                     ];
                     for (let i4 = 0; i4 < availebleItems.length; i4++)
                     {
-                        const sellableItemObj = safeJsonParse<any>($(availebleItems[i4]).attr('data-d'), null);
+                        const sellableItemObj = safeJsonParse<ArmorSlotData | null>($(availebleItems[i4]).attr('data-d'), null);
                         if (!sellableItemObj) { continue; }
                         const indexType = typesOfSets.indexOf(sellableItemObj.id_equip);
     
@@ -723,7 +743,7 @@ export class Shop {
                         else
                         {
                             const currentBest = arraysOfSets[indexType][sellableItemObj.subtype];
-                            const itemCarac = sellableItemObj[caracsOfSets[indexType]];
+                            const itemCarac = Number(sellableItemObj[caracsOfSets[indexType]]);
                             //checking best gear in inventory based on best class stat
                             if (currentBest[0] < itemCarac)
                             {

--- a/src/config/HHStoredVars.ts
+++ b/src/config/HHStoredVars.ts
@@ -2,6 +2,10 @@
 // Defines each variable's storage type (setting vs. temp), default value,
 // validation regex, UI label, and type. Used by the settings menu and storage layer.
 import { getTextForUI } from "../Helper/LanguageHelper";
+// A dependency-free leaf, so this stays within ADR-008 rule 2 ("extract shared
+// constants into dependency-free leaf modules") and adds no import cycle --
+// unlike the PlaceOfPower edge the note below describes.
+import { MYTHIC_LIST_RE } from "../Module/Booster.pure";
 import { deleteStoredValue, getAndStoreCollectPreferences } from "../Helper/StorageHelper";
 import { clearTimer } from "../Helper/TimerHelper";
 import { HHStoredVarPrefixKey, SK, TK } from './StorageKeys';
@@ -114,7 +118,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster] =
     setMenu:true,
     menuType:"value",
     kobanUsing:false,
-    isValid: /^(\s*(MB[1-9]|MB1[0-2])\s*(;\s*(MB[1-9]|MB1[0-2])\s*){0,4})?$/
+    isValid: MYTHIC_LIST_RE
 };
 HHStoredVars[HHStoredVarPrefixKey + SK.autoChamps] =
     {

--- a/src/config/InputPattern.ts
+++ b/src/config/InputPattern.ts
@@ -2,6 +2,7 @@
 // Each pattern constrains what the user can enter in a specific settings field
 // (e.g., timers, thresholds, booster filters).
 
+import { MYTHIC_LIST_PATTERN } from "../Module/Booster.pure";
 import { BUY_LIST_PATTERN } from "../Module/Market.pure";
 
 const thousandsSeparator = (11111).toLocaleString().replace(/1+/g, '');
@@ -17,7 +18,10 @@ export const HHAuto_inputPattern = {
     // Gem Detector could never be entered (#1844).
     autoBuyBoostersFilter: BUY_LIST_PATTERN,
     autoEquipBoostersSlots:"B[1-4](;B[1-4]){0,3}",
-    autoEquipMythicBooster:"(\\s*(MB[1-9]|MB1[0-2])\\s*(;\\s*(MB[1-9]|MB1[0-2])\\s*){0,11})?",
+    // Same story as the buy list above: this field and the isValid check on
+    // the stored value had drifted to different lengths, so a list of more
+    // than five codes was wiped on the next load (#1865).
+    autoEquipMythicBooster: MYTHIC_LIST_PATTERN,
     //calculatePowerLimits:"(\-?[0-9]+;\-?[0-9]+)|default",
     mousePauseTimeout:"[0-9]+",
     safeSecondsForContest:"[0-9]+",


### PR DESCRIPTION
Two commits.

## `fix(booster)` — issue #1865

The *Mythic Slot* field took `MB2;MB3;...;MB12`, and the list was gone the next time the menu was opened.

Two regexes described that field. The `pattern` attribute in `InputPattern.ts` had been widened to twelve codes when the tooltip started saying that listing all of them is the point; the `isValid` entry in `HHStoredVars.ts` still ended in `{0,4}`. `setDefaults` tests the stored value against `isValid` on every page load, found eleven codes invalid and reset the setting to its default. The reporter's debug log names the key and the value it threw away.

Both now read one exported definition, the new dependency-free leaf `src/Module/Booster.pure.ts`, which also hands `parseMythicBoosterList` its per-code regex. Same shape `Market.pure.ts` already has for the buy list after #1844, and what ADR-008 rule 2 asks for; `deps:circular:check` stays on the baseline.

The syntax caps nothing on purpose — the list is a preference order while the five mythic slots are a different number, and the walk down the list stops when no slot is free.

`spec/Module/Booster.pure.spec.ts` runs every value through *both* checks, which is the class of drift that caused this.

A list that was already wiped cannot be recovered and has to be typed again.

## `refactor(shop)`

Unrelated to the above, kept as its own commit: the thirteen explicit `any` annotations in `Shop.ts` get the shapes they actually read. Two are not cosmetic — `settings.data` is `PlainObject | string` and calling `.match` on it blindly would have thrown inside a jQuery handler, and `itemCarac` now goes through `Number()`; both keep the previous branch. Lint ratchet 1046 -> 1031.

## Gates

`typecheck`, `lint:ci`, `deps:circular:check`, `check:gm-grants`, `check:docs`, `check:headers`, `check:player-data` all clean. 95 suites, 1456 tests.

Version 8.11.2, `HHAuto.user.js` rebuilt in the same commit.