### PR TITLE
fix(troll): only let the full harem answer which trolls still have girls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.11.3 - "Last troll with girl" stops locking onto a farmed troll
+
+With *Troll* set to "First/Last troll with girl", the automation kept fighting
+a troll whose girls were long finished, and Love Raids never got a turn
+(issue #1864, reported by Zary; the same setup as #1780).
+
+The count of unfinished girls per troll is built by looking every troll girl up
+in the player's girl list. A girl that is not in the list counts as still to
+win -- so a list that is not the whole harem reports the maximum for every
+troll, which is exactly what a player who owns nothing would get. The harem
+page delivers the whole harem; the home page delivers a much shorter list. In
+the reported log the count came out correct on the harem page and was
+overwritten 29 seconds later on the home page with the maximum for every troll.
+It then stayed that way across three script versions and three months, because
+the harem page is visited rarely and the home page constantly.
+
+A girl list shorter than the harem size the script already keeps cached is no
+longer treated as an answer: the stored count is kept instead of being
+overwritten, and the debug log says so. On a fresh session the count is taken
+from the harem page as before.
+
 ### v8.11.2 - Mythic Slot keeps a list longer than five codes
 
 The *Mythic Slot* field accepted `MB2;MB3;...;MB12`, but the list was gone the

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.11.2
+// @version      8.11.3
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -29348,12 +29348,35 @@ class Troll {
     static getEnergyMax() {
         return Number(getHHVars('Hero.energies.fight.max_regen_amount'));
     }
+    /**
+     * Count, per troll, the girls the player has not finished yet.
+     *
+     * Only the full harem can answer this. Every id that is not in the
+     * dictionary counts as "still to win", so a partial list reports the
+     * maximum for every troll -- indistinguishable from the answer for a
+     * player who owns nothing. Issue #1864: on the harem page the count came
+     * out all zeros, and 29 seconds later the home page handed over a much
+     * shorter `girlsDataList`, which overwrote the snapshot with the maximum
+     * for every troll. That value then stuck for months, because the harem
+     * page is visited rarely and the home page constantly.
+     *
+     * A list shorter than the harem size cached by handleHaremSize therefore
+     * counts as "no answer": [] is returned and the caller keeps whatever
+     * snapshot it has. Without a cached size (fresh install) the check cannot
+     * run and any list is accepted, as before.
+     */
     static getTrollWithGirls() {
         const girlDictionary = Harem.getGirlsList();
         const trollGirlsID = ConfigHelper.getHHScriptVars("trollGirlsID");
         const sideTrollGirlsID = ConfigHelper.getHHScriptVars("sideTrollGirlsID");
         const trollWithGirls = [];
-        if (girlDictionary) {
+        const knownHaremSize = getStoredJSON(HHStoredVarPrefixKey + TK.HaremSize, { count: 0 }).count || 0;
+        if (girlDictionary && girlDictionary.size > 0
+            && knownHaremSize > 0 && girlDictionary.size < knownHaremSize) {
+            logHHAuto(`Girl list holds ${girlDictionary.size} of ${knownHaremSize} known girls, so it is not the harem. Keeping the stored troll snapshot.`);
+            return trollWithGirls;
+        }
+        if (girlDictionary && girlDictionary.size > 0) {
             for (let tIdx = 0; tIdx < trollGirlsID.length; tIdx++) {
                 trollWithGirls[tIdx] = 0;
                 for (let pIdx = 0; pIdx < trollGirlsID[tIdx].length; pIdx++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.11.2",
+  "version": "8.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.11.2",
+      "version": "8.11.3",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.11.2",
+  "version": "8.11.3",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Troll.spec.ts
+++ b/spec/Module/Troll.spec.ts
@@ -1,5 +1,6 @@
 import { getSecondsLeft, setTimer, clearTimer } from '../../src/Helper/TimerHelper';
 import { Troll } from '../../src/Module/Troll';
+import { Harem } from '../../src/Module/harem/Harem';
 import { HHStoredVarPrefixKey } from '../../src/config/HHStoredVars';
 import { SK, TK } from '../../src/config/StorageKeys';
 import { EventGirl } from '../../src/model/EventGirl';
@@ -394,6 +395,54 @@ describe("Troll module", function () {
             };
             localStorage.setItem(HHStoredVarPrefixKey + SK.plusEventMythic, 'true');
             expect(Troll.isTrollFightActivated()).toBeTruthy();
+        });
+    });
+
+    describe("getTrollWithGirls -- only the full harem may answer (issue #1864)", function () {
+        // Every id missing from the dictionary counts as "girl still to win",
+        // so a partial list reports the maximum for every troll. The home page
+        // serves such a list and used to overwrite the correct count taken on
+        // the harem page.
+        const cacheHaremSize = (count: number) =>
+            localStorage.setItem(
+                HHStoredVarPrefixKey + TK.HaremSize,
+                JSON.stringify({ count, count_date: Date.now() }));
+        const dictionaryOf = (size: number, ownedIds: string[] = []) => {
+            const map = new Map<string, { shards: number }>();
+            ownedIds.forEach(id => map.set(id, { shards: 100 }));
+            for (let i = map.size; i < size; i++) map.set("filler" + i, { shards: 100 });
+            return map;
+        };
+
+        it("refuses a list shorter than the cached harem size", function () {
+            cacheHaremSize(680);
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(dictionaryOf(6));
+
+            expect(Troll.getTrollWithGirls()).toEqual([]);
+        });
+
+        it("refuses an empty list", function () {
+            cacheHaremSize(680);
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(new Map());
+
+            expect(Troll.getTrollWithGirls()).toEqual([]);
+        });
+
+        it("counts against a list that is at least the cached harem size", function () {
+            cacheHaremSize(10);
+            // The three main girls of troll 1 on hentaiheroes are 8, 9 and 10.
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(dictionaryOf(10, ['8', '9', '10']));
+
+            const counts = Troll.getTrollWithGirls();
+
+            expect(counts.length).toBeGreaterThan(0);
+            expect(counts[0]).toBe(2); // troll 1: the two extra girls are still missing
+        });
+
+        it("accepts any list while no harem size is cached", function () {
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(dictionaryOf(6));
+
+            expect(Troll.getTrollWithGirls().length).toBeGreaterThan(0);
         });
     });
 

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -48,13 +48,37 @@ export class Troll {
         return Number(getHHVars('Hero.energies.fight.max_regen_amount'));
     }
 
+    /**
+     * Count, per troll, the girls the player has not finished yet.
+     *
+     * Only the full harem can answer this. Every id that is not in the
+     * dictionary counts as "still to win", so a partial list reports the
+     * maximum for every troll -- indistinguishable from the answer for a
+     * player who owns nothing. Issue #1864: on the harem page the count came
+     * out all zeros, and 29 seconds later the home page handed over a much
+     * shorter `girlsDataList`, which overwrote the snapshot with the maximum
+     * for every troll. That value then stuck for months, because the harem
+     * page is visited rarely and the home page constantly.
+     *
+     * A list shorter than the harem size cached by handleHaremSize therefore
+     * counts as "no answer": [] is returned and the caller keeps whatever
+     * snapshot it has. Without a cached size (fresh install) the check cannot
+     * run and any list is accepted, as before.
+     */
     static getTrollWithGirls() {
         const girlDictionary = Harem.getGirlsList();
         const trollGirlsID = ConfigHelper.getHHScriptVars("trollGirlsID");
         const sideTrollGirlsID = ConfigHelper.getHHScriptVars("sideTrollGirlsID");
         const trollWithGirls:number[] = [];
-    
-        if (girlDictionary) {
+        const knownHaremSize = getStoredJSON(HHStoredVarPrefixKey + TK.HaremSize, { count: 0 }).count || 0;
+
+        if (girlDictionary && girlDictionary.size > 0
+            && knownHaremSize > 0 && girlDictionary.size < knownHaremSize) {
+            logHHAuto(`Girl list holds ${girlDictionary.size} of ${knownHaremSize} known girls, so it is not the harem. Keeping the stored troll snapshot.`);
+            return trollWithGirls;
+        }
+
+        if (girlDictionary && girlDictionary.size > 0) {
             for (let tIdx = 0; tIdx < trollGirlsID.length; tIdx++) {
                 trollWithGirls[tIdx] = 0;
                 for (let pIdx = 0; pIdx < trollGirlsID[tIdx].length; pIdx++) {


### PR DESCRIPTION
Issue #1864, same setup as #1780.

With *Troll* set to "First/Last troll with girl" the automation kept fighting a troll whose girls were long finished, and Love Raids never got a turn.

## What decides it

`Troll.getTrollWithGirls()` counts, per troll, the girls that are not in the player's girl list. A girl missing from the list counts as still to win, so a list that is not the whole harem returns the maximum for every troll — the same answer a player who owns nothing would get. The array carries no marker of where it came from, and `getTrollIdToFight` stored it as confidently as a real count.

The reported log has both cases 29 seconds apart:

```
2:51:10  waifu   list available  ->  "No valid troll target found"   (all zeros)
2:51:39  home    list available  ->  "Fighting troll N°13"           (non-zero)
```

The reporter's cached harem size is 680. The home page's `girlsDataList` is far shorter, so on the home page every troll girl counts as missing. That is why `[3,3,3,3,3,3,3,3,3,3,3,3,0]` appears byte for byte in three logs across three script versions and three months, and why the #1780 fix did not help: refreshing more often does not help when a failed read outranks a good one and the home page is visited constantly while the harem page is not.

## Change

A girl list shorter than the harem size `handleHaremSize` already caches is no longer an answer: `[]` is returned, the caller keeps its stored snapshot, and the debug log names both numbers. An empty Map no longer counts as a list either — `if (girlDictionary)` was true for it. Without a cached size (fresh install) the check cannot run and any list is accepted, as before.

A fresh session starts with an empty snapshot and takes it from the harem page, which is the path that was always correct.

## Tests

Four cases in `spec/Module/Troll.spec.ts`. Against the previous code the two guard tests fail:

```
✕ refuses a list shorter than the cached harem size
✕ refuses an empty list
```

The two positive cases pass either way; one of them checks against the real hentaiheroes config data that troll 1 reports 2 when three of its five girls are owned.

## Not in scope

"First/Last troll with girl" still outranks Love Raids. With a correct count that no longer matters for this report; if it turns out not to be enough, the ordering is the next thing to look at.

## Gates

`typecheck`, `lint:ci`, `deps:circular:check`, `check:gm-grants`, `check:docs`, `check:headers`, `check:player-data` all clean. 95 suites, 1460 tests.

Version 8.11.3, `HHAuto.user.js` rebuilt in the same commit.