### PR TITLE
fix(pachinko): stop an x-times run when no girls are left to win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.11.4 - Pachinko x-times stops when there are no girls left
+
+The *Pachinko ×N* run kept pulling on the Epic pachinko after the last girl was
+gone, while it stopped as expected on the Mythic one (issue #1863, reported by
+Zary).
+
+The script had no stop of its own. It watched for the game's "no girls"
+confirmation popup and stopped on that -- which is what the *Bypass no girls*
+switch turns off. The game does not raise that popup on every pachinko, and
+where it does not, nothing ended the run.
+
+The script now counts the girls itself, the same number it already prints as
+"N girls to win" in the pachinko menu, and stops on its own: before a run
+starts, and again whenever it would fire another pull, so a run also ends when
+the last girl is won mid-run. *Bypass no girls* still turns the whole thing off,
+and the Equipment pachinko is exempt because it never offers girls.
+
+Counting had to be corrected for that: the Mythic pachinko marks its girls
+differently from the others, and the old count reported zero for a Mythic pool
+that held three girls. A page that does not show its prize list at all is not
+counted as "no girls" either -- it is not an answer.
+
 ### v8.11.3 - "Last troll with girl" stops locking onto a farmed troll
 
 With *Troll* set to "First/Last troll with girl", the automation kept fighting

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.11.3
+// @version      8.11.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -22821,18 +22821,68 @@ class Pachinko {
             }
         });
     }
+    /**
+     * Girls still to win in the pachinko the page is showing.
+     *
+     * Two markers, because the game uses two. Measured 2026-09-02 across all
+     * five panels: Event and Epic carry `.girl_shards`, Mythic carries
+     * `.pachinko-pool-girl` instead (class list "blue_circular_btn
+     * pachinko-pool-girl girls_reward reward-ico"). Reading only the first one
+     * reported 0 for a Mythic pachinko that had three girls in its pool, which
+     * would have stopped the one pachinko that was working (issue #1863).
+     *
+     * Equipment carries neither -- its prize row is `girl_armor`, equipment
+     * with a girl's picture on it. See PANEL_WITHOUT_GIRLS.
+     */
     static getNumberOfGirlToWinPatchinko() {
-        const girlsRewards = $("div.playing-zone .game-rewards .list-prizes .girl_shards");
+        const girlsRewards = $("div.playing-zone .game-rewards .list-prizes .girl_shards, div.playing-zone .game-rewards .list-prizes .pachinko-pool-girl");
         let numberOfGirlsToWin = 0;
-        if (girlsRewards.length > 0) {
+        girlsRewards.each(function () {
             try {
-                numberOfGirlsToWin = safeJsonParse(girlsRewards.attr("data-rewards"), []).length;
+                numberOfGirlsToWin += safeJsonParse($(this).attr("data-rewards"), []).length;
             }
             catch (exp) {
                 logHHAuto('Could not count pachinko girls to win: ' + exp);
             }
-        }
+        });
         return numberOfGirlsToWin;
+    }
+    /**
+     * Which pachinko the page is showing, from the game's own attribute on
+     * div.playing-zone: event / epic / mythic / equipment / great (measured
+     * 2026-09-02). Preferred over the heading, which is translated, and over
+     * the orb names, which differ per panel and per game.
+     */
+    static getPachinkoPanelType() {
+        var _a;
+        return (_a = $("div.playing-zone").attr("type-panel")) !== null && _a !== void 0 ? _a : '';
+    }
+    /**
+     * Whether an X-run must stop because there is nothing left to win.
+     *
+     * Until #1863 the only stop was the game's own "no girls" warning popup,
+     * which the script watches for as #confirm_pachinko. The game does not
+     * raise it everywhere, so on Epic the run kept going. The script counts the
+     * girls itself for the menu ("N girls to win") and can decide on its own.
+     *
+     * `prizesReadable` says whether the prize list was on the page at all. A
+     * count of zero taken from a page that never showed the list is not an
+     * answer, and treating it as one would stop every run that happens to look
+     * while the zone is not rendered.
+     *
+     * Pure counterpart to the DOM reads, so the rule is testable on its own.
+     */
+    static decideStopForNoGirls(bypassChecked, panelType, girlsToWin, prizesReadable) {
+        if (bypassChecked)
+            return false;
+        if (!prizesReadable)
+            return false;
+        if (panelType === Pachinko.PANEL_WITHOUT_GIRLS)
+            return false;
+        return girlsToWin <= 0;
+    }
+    static mustStopForNoGirls() {
+        return Pachinko.decideStopForNoGirls(Pachinko.ByPassNoGirlChecked, Pachinko.getPachinkoPanelType(), Pachinko.getNumberOfGirlToWinPatchinko(), $("div.playing-zone .game-rewards .list-prizes").length > 0);
     }
     static getNumberOfOrbsLeft(buttonSelector) {
         let orbsLeft = 0;
@@ -22957,6 +23007,13 @@ class Pachinko {
         const selectedOption = Pachinko.pachinkoSelector.options[Pachinko.pachinkoSelector.selectedIndex];
         const buttonSelector = Pachinko.getSelectedOptionButtonSelector();
         Pachinko.orbsToGo = Number(document.getElementById("PachinkoXTimes").value);
+        // Nothing to win, nothing to spend orbs on. Checked here as well as in
+        // every round, so a run cannot even start on an emptied pachinko.
+        if (Pachinko.mustStopForNoGirls()) {
+            logHHAuto('No girl left on this pachinko, not starting the run.');
+            $("#PachinkoError").text(getTextForUI("PachinkoNoGirls", "elementText"));
+            return;
+        }
         Pachinko.orbLeftOnAutoStart = Pachinko.getNumberOfOrbsLeft(buttonSelector);
         if (Pachinko.orbLeftOnAutoStart <= 0) {
             logHHAuto('No Orbs left for : ' + selectedOption.text);
@@ -23065,6 +23122,21 @@ class Pachinko {
             const continuePachinkoSelectedButton = $(buttonContinueSelector);
             $("#PachinkoPlayedTimes").text(spendedOrbs + "/" + Pachinko.orbsToGo);
             if (Pachinko.shouldContinuePachinkoRun(Pachinko.orbLeftOnAutoStart, currentOrbsLeft, Pachinko.orbsToGo)) {
+                // The game's own warning (#confirm_pachinko above) is not raised on
+                // every pachinko, so the count decides as well -- and it can drop to
+                // zero mid-run, when the last girl is won (issue #1863). Checked here
+                // rather than at the top of the round so a run that has reached its
+                // target still ends through the branch below, which reloads the page
+                // against the played-games desync (#1799) and reports the orbs spent.
+                if (Pachinko.mustStopForNoGirls()) {
+                    RewardHelper.closeRewardPopupIfAny(false);
+                    logHHAuto(`No girl left on this pachinko, stopping after ${spendedOrbs}/${Pachinko.orbsToGo} orbs.`);
+                    Pachinko.stopXPachinkoNoGirl();
+                    if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPachinko")) {
+                        safeReload();
+                    }
+                    return;
+                }
                 if (continuePachinkoSelectedButton.length > 0) {
                     continuePachinkoSelectedButton.trigger('click');
                 }
@@ -23241,6 +23313,8 @@ Pachinko.retry = 0;
 // server play-response. Preferred over the DOM counter, which can lag during
 // fast runs and cause over-consumption past the requested amount (issue 1745).
 Pachinko.serverOrbsLeft = undefined;
+/** The one pachinko that never offers girls; its prizes are girl_armor. */
+Pachinko.PANEL_WITHOUT_GIRLS = 'equipment';
 
 ;// ./src/Module/Shop.pure.ts
 // Shop.pure.ts -- Pure decision logic for the market (shop) visit trigger.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.11.3",
+  "version": "8.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.11.3",
+      "version": "8.11.4",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.11.3",
+  "version": "8.11.4",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/scripts/live-check/checks.json
+++ b/scripts/live-check/checks.json
@@ -201,6 +201,34 @@
       "note": "An unknown prefix means the mapping table needs a new case, not that the check is broken."
     },
     {
+      "id": "pachinko-panel-type",
+      "claim": "div.playing-zone carries the game's own panel discriminator",
+      "source": "src/Module/Pachinko.ts (getPachinkoPanelType, PANEL_WITHOUT_GIRLS)",
+      "page": "/pachinko.html",
+      "kind": "harvest",
+      "selector": "div.playing-zone[type-panel]",
+      "attribute": "type-panel",
+      "extract": "value",
+      "allow": [
+        "^(event|epic|mythic|equipment|great)$"
+      ],
+      "note": "Measured 2026-09-02, one panel per visit: event/epic/mythic/equipment/great. Only 'equipment' never offers girls. A new value means the no-girls stop has an unclassified panel, not that the check is broken."
+    },
+    {
+      "id": "pachinko-girl-markers",
+      "claim": "girls to win are marked by .girl_shards or .pachinko-pool-girl inside .list-prizes",
+      "source": "src/Module/Pachinko.ts (getNumberOfGirlToWinPatchinko)",
+      "page": "/pachinko.html",
+      "kind": "harvest",
+      "selector": "div.playing-zone .game-rewards .list-prizes > *",
+      "attribute": "class",
+      "extract": "value",
+      "allow": [
+        "girls_reward"
+      ],
+      "note": "Measured 2026-09-02: Event/Epic use girl_shards, Mythic uses pachinko-pool-girl, Equipment only girl_armor. One panel is visible per visit, so this harvests whichever is open."
+    },
+    {
       "id": "girl-equipment-slots",
       "claim": "the girl equipment tab still renders six .equipment_slot elements",
       "source": "src/Module/harem/HaremGirl.ts (optimizeEquipmentSlots)",

--- a/spec/Module/Pachinko.spec.ts
+++ b/spec/Module/Pachinko.spec.ts
@@ -83,6 +83,110 @@ describe("Pachinko", function() {
       expect(Pachinko.shouldContinuePachinkoRun(100, 0, 50)).toBe(false);
     });
   });
+  describe("no-girls stop (issue #1863)", function() {
+    // The DOM shapes below are what the live page served on 2026-09-02, one
+    // panel each. Event and Epic mark their girls with .girl_shards, Mythic
+    // with .pachinko-pool-girl, Equipment with neither.
+    const zone = (panelType: string, prizes: string) =>
+      `<div class="playing-zone" type-panel="${panelType}">`
+      + `<div class="game-rewards"><div class="list-prizes">${prizes}</div></div></div>`;
+    const shards = (n: number) =>
+      `<div class="pachinko-tooltip girls_reward reward-ico girl_shards" data-rewards='${JSON.stringify(new Array(n).fill({ id_girl: 1 }))}'></div>`;
+    const pool = (n: number) =>
+      `<div class="blue_circular_btn pachinko-pool-girl girls_reward reward-ico" data-rewards='${JSON.stringify(new Array(n).fill({ id_girl: 1 }))}'></div>`;
+    const armor = (n: number) =>
+      `<div class="pachinko-tooltip girls_reward reward-ico girl_armor" data-rewards='${JSON.stringify(new Array(n).fill({ rarity: "legendary" }))}'></div>`;
+
+    afterEach(() => { document.body.innerHTML = ""; });
+
+    describe("counting", function() {
+      it("counts the .girl_shards marker (Event, Epic)", function() {
+        document.body.innerHTML = zone('epic', shards(5));
+        expect(Pachinko.getNumberOfGirlToWinPatchinko()).toBe(5);
+      });
+
+      it("counts the .pachinko-pool-girl marker the Mythic pachinko uses", function() {
+        // Reading only .girl_shards reported 0 here while three girls were in
+        // the pool -- that would have stopped the pachinko that still worked.
+        document.body.innerHTML = zone('mythic', pool(3));
+        expect(Pachinko.getNumberOfGirlToWinPatchinko()).toBe(3);
+      });
+
+      it("does not count girl_armor as a girl", function() {
+        document.body.innerHTML = zone('equipment', armor(5));
+        expect(Pachinko.getNumberOfGirlToWinPatchinko()).toBe(0);
+      });
+
+      it("counts nothing when no marker is present", function() {
+        document.body.innerHTML = zone('great', '');
+        expect(Pachinko.getNumberOfGirlToWinPatchinko()).toBe(0);
+      });
+
+      it("reads the panel type the game puts on the playing zone", function() {
+        document.body.innerHTML = zone('mythic', pool(3));
+        expect(Pachinko.getPachinkoPanelType()).toBe('mythic');
+      });
+
+      it("reports an empty panel type when the zone is not on the page", function() {
+        expect(Pachinko.getPachinkoPanelType()).toBe('');
+      });
+    });
+
+    describe("decideStopForNoGirls", function() {
+      it.each([
+        ['great', 0, true, 'no girls left'],
+        ['epic', 0, true, 'no girls left'],
+        ['mythic', 0, true, 'no girls left'],
+        ['event', 0, true, 'no girls left'],
+        ['great', 2, false, 'girls left'],
+        ['equipment', 0, false, 'equipment never has girls'],
+      ])("panel %s with %i girls -> stop %s (%s)", (panel, girls, expected) => {
+        expect(Pachinko.decideStopForNoGirls(false, panel as string, girls as number, true)).toBe(expected);
+      });
+
+      it("never stops while Bypass no girls is on", function() {
+        expect(Pachinko.decideStopForNoGirls(true, 'great', 0, true)).toBe(false);
+        expect(Pachinko.decideStopForNoGirls(true, 'epic', 0, true)).toBe(false);
+      });
+
+      it("does not stop when the prize list was not on the page at all", function() {
+        // A count of zero read from a page that never showed the list is not an
+        // answer. Treating it as one would end every run that looks while the
+        // playing zone is not rendered.
+        expect(Pachinko.decideStopForNoGirls(false, 'epic', 0, false)).toBe(false);
+        expect(Pachinko.decideStopForNoGirls(false, '', 0, false)).toBe(false);
+      });
+    });
+
+    describe("mustStopForNoGirls", function() {
+      afterEach(() => { Pachinko.ByPassNoGirlChecked = false; });
+
+      it("does not stop when the playing zone is not on the page", function() {
+        document.body.innerHTML = "";
+        Pachinko.ByPassNoGirlChecked = false;
+        expect(Pachinko.mustStopForNoGirls()).toBe(false);
+      });
+
+      it("stops an Epic pachinko whose girls are gone", function() {
+        document.body.innerHTML = zone('epic', '');
+        Pachinko.ByPassNoGirlChecked = false;
+        expect(Pachinko.mustStopForNoGirls()).toBe(true);
+      });
+
+      it("keeps going on a Mythic pachinko that still has a pool", function() {
+        document.body.innerHTML = zone('mythic', pool(3));
+        Pachinko.ByPassNoGirlChecked = false;
+        expect(Pachinko.mustStopForNoGirls()).toBe(false);
+      });
+
+      it("keeps going on the Equipment pachinko", function() {
+        document.body.innerHTML = zone('equipment', armor(5));
+        Pachinko.ByPassNoGirlChecked = false;
+        expect(Pachinko.mustStopForNoGirls()).toBe(false);
+      });
+    });
+  });
+
   describe("cancelXPachinkoRun", function() {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/src/Module/Pachinko.ts
+++ b/src/Module/Pachinko.ts
@@ -126,15 +126,71 @@ export class Pachinko {
         }
     }
 
+    /**
+     * Girls still to win in the pachinko the page is showing.
+     *
+     * Two markers, because the game uses two. Measured 2026-09-02 across all
+     * five panels: Event and Epic carry `.girl_shards`, Mythic carries
+     * `.pachinko-pool-girl` instead (class list "blue_circular_btn
+     * pachinko-pool-girl girls_reward reward-ico"). Reading only the first one
+     * reported 0 for a Mythic pachinko that had three girls in its pool, which
+     * would have stopped the one pachinko that was working (issue #1863).
+     *
+     * Equipment carries neither -- its prize row is `girl_armor`, equipment
+     * with a girl's picture on it. See PANEL_WITHOUT_GIRLS.
+     */
     static getNumberOfGirlToWinPatchinko() {
-        const girlsRewards = $("div.playing-zone .game-rewards .list-prizes .girl_shards");
+        const girlsRewards = $("div.playing-zone .game-rewards .list-prizes .girl_shards, div.playing-zone .game-rewards .list-prizes .pachinko-pool-girl");
         let numberOfGirlsToWin = 0;
-        if (girlsRewards.length > 0) {
+        girlsRewards.each(function () {
             try {
-                numberOfGirlsToWin = safeJsonParse(girlsRewards.attr("data-rewards"), []).length;
+                numberOfGirlsToWin += safeJsonParse($(this).attr("data-rewards"), []).length;
             } catch (exp) { logHHAuto('Could not count pachinko girls to win: ' + exp); }
-        }
+        });
         return numberOfGirlsToWin;
+    }
+
+    /**
+     * Which pachinko the page is showing, from the game's own attribute on
+     * div.playing-zone: event / epic / mythic / equipment / great (measured
+     * 2026-09-02). Preferred over the heading, which is translated, and over
+     * the orb names, which differ per panel and per game.
+     */
+    static getPachinkoPanelType(): string {
+        return $("div.playing-zone").attr("type-panel") ?? '';
+    }
+
+    /** The one pachinko that never offers girls; its prizes are girl_armor. */
+    static PANEL_WITHOUT_GIRLS = 'equipment';
+
+    /**
+     * Whether an X-run must stop because there is nothing left to win.
+     *
+     * Until #1863 the only stop was the game's own "no girls" warning popup,
+     * which the script watches for as #confirm_pachinko. The game does not
+     * raise it everywhere, so on Epic the run kept going. The script counts the
+     * girls itself for the menu ("N girls to win") and can decide on its own.
+     *
+     * `prizesReadable` says whether the prize list was on the page at all. A
+     * count of zero taken from a page that never showed the list is not an
+     * answer, and treating it as one would stop every run that happens to look
+     * while the zone is not rendered.
+     *
+     * Pure counterpart to the DOM reads, so the rule is testable on its own.
+     */
+    static decideStopForNoGirls(bypassChecked: boolean, panelType: string, girlsToWin: number, prizesReadable: boolean): boolean {
+        if (bypassChecked) return false;
+        if (!prizesReadable) return false;
+        if (panelType === Pachinko.PANEL_WITHOUT_GIRLS) return false;
+        return girlsToWin <= 0;
+    }
+
+    static mustStopForNoGirls(): boolean {
+        return Pachinko.decideStopForNoGirls(
+            Pachinko.ByPassNoGirlChecked,
+            Pachinko.getPachinkoPanelType(),
+            Pachinko.getNumberOfGirlToWinPatchinko(),
+            $("div.playing-zone .game-rewards .list-prizes").length > 0);
     }
     
     static getNumberOfOrbsLeft(buttonSelector: string): number {
@@ -278,6 +334,14 @@ export class Pachinko {
         const buttonSelector = Pachinko.getSelectedOptionButtonSelector();
         Pachinko.orbsToGo = Number((<HTMLInputElement>document.getElementById("PachinkoXTimes")).value);
 
+        // Nothing to win, nothing to spend orbs on. Checked here as well as in
+        // every round, so a run cannot even start on an emptied pachinko.
+        if (Pachinko.mustStopForNoGirls()) {
+            logHHAuto('No girl left on this pachinko, not starting the run.');
+            $("#PachinkoError").text(getTextForUI("PachinkoNoGirls", "elementText"));
+            return;
+        }
+
         Pachinko.orbLeftOnAutoStart = Pachinko.getNumberOfOrbsLeft(buttonSelector);
         if (Pachinko.orbLeftOnAutoStart <= 0) {
             logHHAuto('No Orbs left for : ' + selectedOption.text);
@@ -387,6 +451,21 @@ export class Pachinko {
         const continuePachinkoSelectedButton = $(buttonContinueSelector);
         $("#PachinkoPlayedTimes").text(spendedOrbs + "/" + Pachinko.orbsToGo);
         if (Pachinko.shouldContinuePachinkoRun(Pachinko.orbLeftOnAutoStart, currentOrbsLeft, Pachinko.orbsToGo)) {
+            // The game's own warning (#confirm_pachinko above) is not raised on
+            // every pachinko, so the count decides as well -- and it can drop to
+            // zero mid-run, when the last girl is won (issue #1863). Checked here
+            // rather than at the top of the round so a run that has reached its
+            // target still ends through the branch below, which reloads the page
+            // against the played-games desync (#1799) and reports the orbs spent.
+            if (Pachinko.mustStopForNoGirls()) {
+                RewardHelper.closeRewardPopupIfAny(false);
+                logHHAuto(`No girl left on this pachinko, stopping after ${spendedOrbs}/${Pachinko.orbsToGo} orbs.`);
+                Pachinko.stopXPachinkoNoGirl();
+                if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPachinko")) {
+                    safeReload();
+                }
+                return;
+            }
             if (continuePachinkoSelectedButton.length > 0) {
                 continuePachinkoSelectedButton.trigger('click');
             }


### PR DESCRIPTION
Issue #1863.

The *Pachinko ×N* run kept pulling on the Epic pachinko after the last girl was gone, while it stopped as expected on the Mythic one.

## What decides it

The script had no stop of its own. It watched for the game's `#confirm_pachinko` warning and ended the run on that — the popup the *Bypass no girls* switch exists to skip. The game does not raise it on every pachinko, and where it does not, nothing ended the run.

The number was already there: `getNumberOfGirlToWinPatchinko()` is what prints "N girls to win" in the pachinko menu. It was displayed and never acted on — `grep` found exactly one use.

## Measured

Live page, 2026-09-02, one visit per panel:

| panel (`type-panel`) | orbs | girls marked by |
|---|---|---|
| `event` | `o_v4` | `.girl_shards` |
| `epic` | `o_e1`, `o_e10`, `o_ed` | `.girl_shards` |
| `mythic` | `o_m1`, `o_m3`, `o_m6` | `.pachinko-pool-girl` |
| `equipment` | `o_eq1`, `o_eq2`, `o_eq10` | none — `girl_armor` instead |
| `great` | `o_g1`, `o_g10` | none open at the time |

Two things this changed:

- The Mythic pachinko marks its girls with `.pachinko-pool-girl`, not `.girl_shards`. The old count reported 0 for a pool that held three — a naive "stop at zero" would have stopped the one pachinko that still worked.
- `div.playing-zone` carries `type-panel`, the game's own discriminator. Language-independent, unlike the heading, and stable, unlike the orb names. `equipment` is the one panel that never offers girls.

Button colour is a state, not a type: orange = kobans, blue = orbs in stock, green also seen on `o_g1`/`o_eq1`.

## Change

Both markers are counted. The run stops before it starts and wherever it would fire another pull, so it also ends when the last girl is won mid-run. *Bypass no girls* still turns the whole thing off; `equipment` is exempt by panel type.

Two placements matter:

- The check sits **inside** the continue branch. In front of it, a run that reached its target would skip the finish path that reloads against the played-games desync (#1799) and reports the orbs spent.
- A page that does not show its prize list at all is **not** counted as "no girls". A zero from a page that never rendered the zone is not an answer.

Both were caught by the existing #1799 tests, not by review.

## Tests

18 cases in `spec/Module/Pachinko.spec.ts`, with the DOM shapes the live page served — one per panel. The live check gains `pachinko-panel-type` and `pachinko-girl-markers`, so both claims about the page are checked before a release.

## Gates

`typecheck`, `lint:ci`, `deps:circular:check`, `check:gm-grants`, `check:docs`, `check:headers`, `check:player-data` all clean. 95 suites, 1478 tests.

Version 8.11.4, `HHAuto.user.js` rebuilt in the same commit.