### PR TITLE
fix(login-script): stop the enter-game click hitting the login button

### DIFF
--- a/bonus-scripts/HHAuto-Login.user.js
+++ b/bonus-scripts/HHAuto-Login.user.js
@@ -3,7 +3,7 @@
 // @namespace    https://github.com/OldRon1977/HHauto
 // @version      1.3
 // @description  HHAuto Login
-// @author       Zary
+// @author       Zary, OldRon1977
 // @match        https://connect.chibipass.com/*
 // @match        http*://*.haremheroes.com/
 // @match        http*://*.hentaiheroes.com/
@@ -22,18 +22,18 @@
 //
 // WHAT THIS SCRIPT DOES
 // It types your ChibiPass e-mail and password into the login form for you and
-// clicks the login button, then clicks "enter game" on the game's landing page.
-// That is the whole feature. It is a convenience helper for logging in, nothing
-// more.
+// clicks the login button, then clicks the "enter game" button on the game's
+// landing page if one is shown. That is the whole feature. It is a convenience
+// helper for logging in, nothing more.
 //
 // IT SENDS NOTHING ANYWHERE
 // Your credentials go into the two input fields of the official ChibiPass login
-// page and nowhere else -- exactly where you would type them yourself. The
+// form and nowhere else -- exactly where you would type them yourself. The
 // script contains no fetch, no XMLHttpRequest, no sendBeacon, no WebSocket, no
 // image or link tricks, and it declares "@grant none", so it has no access to
 // privileged userscript APIs at all. It does not read cookies, it does not touch
 // localStorage or sessionStorage, and it reports nothing to the author or to any
-// third party. You can verify every word of that by reading the 100 lines below.
+// third party. You can verify every word of that by reading the code below.
 //
 // THE RISK, PLAINLY
 // The risk is not transmission. The risk is THE FILE ITSELF: once you fill in
@@ -63,22 +63,29 @@
 // SCOPE
 // The @match list is intentionally minimal: the ChibiPass login form (where the
 // credentials are entered) plus the landing page ("/") of each game domain,
-// where the "enter game" button lives. Do not widen it; every extra page a
-// credential-bearing script runs on increases exposure. Remove the game domains
-// you do not play.
+// which is where the enter-game click belongs. Do not widen it; every extra
+// page a credential-bearing script runs on increases exposure. Remove the game
+// domains you do not play.
 //
-// The ChibiPass entry is not a page of its own. The form is served into an
-// iframe of the game's landing page
-// (connect.chibipass.com/authentication/start_authentication?product_id=...),
-// so this script only reaches it because it does not declare @noframes. That
-// line carries the whole login half -- do not add @noframes, and do not drop
-// the chibipass @match as unused.
+// The ChibiPass entry is not a page of its own. Its bare root serves an empty
+// document; the form is delivered as an iframe of the game's home.html, which
+// the landing page in turn holds in its #hh_game iframe:
+//
+//     /                                    <- landing page, enterGame() runs here
+//     +- /home.html                        <- the game itself
+//        +- connect.chibipass.com/authentication/start_authentication?...
+//                                          <- the form, login() runs here
+//
+// So the script only reaches the form because it does not declare @noframes.
+// That is what carries the login half -- do not add @noframes, and do not drop
+// the chibipass @match as unused. Because that @match is tested against the
+// frame's own URL, the login works from either entry point; the enter-game half
+// only runs when the landing page "/" is the top document.
 // ==============================================================================
 
 const userEmail = "YOUR_EMAIL";
 const userPass = "YOUR_PASSWORD";
 
-// Waiting for the element to appear.
 function waitForElement(selector, timeout = 10000) {
     return new Promise((resolve, reject) => {
         const interval = 200;
@@ -100,7 +107,7 @@ function waitForElement(selector, timeout = 10000) {
     });
 }
 
-// LOGIN (ChibiPass)
+// Runs inside the ChibiPass form iframe (see SCOPE above).
 async function login() {
     try {
         const email = await waitForElement("#auth-email");
@@ -110,7 +117,12 @@ async function login() {
         email.value = userEmail;
         pass.value = userPass;
 
-        // Forces frameworks (React/Vue) to detect change.
+        // The page's own validation listens for these, and dispatching them
+        // is what makes it accept the values and enable the submit button.
+        // The form is plain server-rendered HTML -- no React, no Vue, no value
+        // tracker on the inputs -- so assigning .value directly is enough. An
+        // input backed by a framework would ignore this and need the native
+        // value setter instead.
         ["input", "change"].forEach(evt => {
             email.dispatchEvent(new Event(evt, { bubbles: true }));
             pass.dispatchEvent(new Event(evt, { bubbles: true }));
@@ -129,7 +141,7 @@ async function login() {
     }
 }
 
-// ENTER THE GAME (iframe)
+// Runs on the game's landing page, which holds the game in an #hh_game iframe.
 function enterGame() {
     const maxAttempts = 30; // 30 x 2s -- one minute, then give up quietly
     let attempts = 0;
@@ -152,7 +164,9 @@ function enterGame() {
                 return true;
             }
         } catch (e) {
-            // Ignore cross-origin error
+            // contentDocument throws on a cross-origin iframe. It is
+            // same-origin on hentaiheroes.com, so this is a guard for the
+            // other domains, not the normal path.
         }
 
         return false;
@@ -163,7 +177,6 @@ function enterGame() {
     }, 2000);
 }
 
-// CONTEXT DETECTION
 function isLoginPage() {
     return window.location.hostname.includes("chibipass.com");
 }
@@ -172,7 +185,6 @@ function isGamePage() {
     return !isLoginPage();
 }
 
-// INIT
 function init() {
     if (!userEmail || !userPass
         || userEmail === "YOUR_EMAIL" || userPass === "YOUR_PASSWORD") {

--- a/bonus-scripts/HHAuto-Login.user.js
+++ b/bonus-scripts/HHAuto-Login.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HHAuto Login
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      1.2
+// @version      1.3
 // @description  HHAuto Login
 // @author       Zary
 // @match        https://connect.chibipass.com/*
@@ -61,11 +61,18 @@
 // by hand. HHAuto itself works fine without it.
 //
 // SCOPE
-// The @match list is intentionally minimal: the ChibiPass login page (where the
+// The @match list is intentionally minimal: the ChibiPass login form (where the
 // credentials are entered) plus the landing page ("/") of each game domain,
 // where the "enter game" button lives. Do not widen it; every extra page a
 // credential-bearing script runs on increases exposure. Remove the game domains
 // you do not play.
+//
+// The ChibiPass entry is not a page of its own. The form is served into an
+// iframe of the game's landing page
+// (connect.chibipass.com/authentication/start_authentication?product_id=...),
+// so this script only reaches it because it does not declare @noframes. That
+// line carries the whole login half -- do not add @noframes, and do not drop
+// the chibipass @match as unused.
 // ==============================================================================
 
 const userEmail = "YOUR_EMAIL";
@@ -109,7 +116,11 @@ async function login() {
             pass.dispatchEvent(new Event(evt, { bubbles: true }));
         });
 
-        btn.disabled = false;
+        // The page enables the button itself once it has seen both inputs.
+        // Only force it if that did not happen: after the click the page sets
+        // disabled again as its own guard against a double submit, and
+        // clearing it unconditionally would defeat that guard.
+        if (btn.disabled) btn.disabled = false;
         btn.click();
 
         console.log("Login sent");
@@ -120,6 +131,9 @@ async function login() {
 
 // ENTER THE GAME (iframe)
 function enterGame() {
+    const maxAttempts = 30; // 30 x 2s -- one minute, then give up quietly
+    let attempts = 0;
+
     const tryClick = () => {
         const iframe = document.querySelector("#hh_game");
         if (!iframe) return false;
@@ -128,7 +142,11 @@ function enterGame() {
             const innerDoc = iframe.contentDocument || iframe.contentWindow.document;
             const btn = innerDoc?.querySelector(".igreen");
 
-            if (btn) {
+            // While logged out, the only .igreen on the landing page is the
+            // login icon inside a[rel='phoenix_member_login']. Clicking that
+            // and stopping would end the search before the enter-game button
+            // has appeared, so skip it and keep looking.
+            if (btn && !btn.closest("a[rel='phoenix_member_login']")) {
                 btn.click();
                 console.log("Entered the game.");
                 return true;
@@ -141,7 +159,7 @@ function enterGame() {
     };
 
     const interval = setInterval(() => {
-        if (tryClick()) clearInterval(interval);
+        if (tryClick() || ++attempts >= maxAttempts) clearInterval(interval);
     }, 2000);
 }
 
@@ -169,6 +187,9 @@ function init() {
     }
 }
 
-// Ensures execution even on SPA (React) pages.
+// "load" is the one start point. At the default @run-at document-end the
+// DOMContentLoaded event has already been dispatched, so a listener for it
+// never fires; at document-start both would fire and init would run twice,
+// submitting the form a second time. The ChibiPass form is server-rendered,
+// not an SPA, so there is nothing later to wait for.
 window.addEventListener("load", init);
-document.addEventListener("DOMContentLoaded", init);

--- a/bonus-scripts/README.md
+++ b/bonus-scripts/README.md
@@ -22,6 +22,8 @@ purpose — remove the domains you do not play, and do not widen the list.
 
 1. Install the script, fill in `userEmail` / `userPass`.
 2. Log out of the game and open the game domain root (e.g. `https://www.hentaiheroes.com/`).
-3. Complete the ChibiPass redirect: the form on `connect.chibipass.com` must be filled and submitted automatically ("Login sent" in the console).
+3. The ChibiPass form is served into an iframe of that same page, not as a
+   separate redirect. It must be filled and submitted automatically ("Login
+   sent" in the console of the `connect.chibipass.com` frame).
 4. Back on the landing page, the "enter game" button must be clicked automatically ("Entered the game." in the console).
 5. Verify the script does **not** run inside the game (no console entries on `/home.html`).


### PR DESCRIPTION
Verified against the live pages on 2026-09-03, logged out, with the ChibiPass
auth request intercepted before it left the browser. Tested end to end by the
maintainer afterwards: `Login sent`, session established, HHauto's pipeline
running, and no stray click.

## The bug

While logged out, the only `.igreen` on the game's landing page is the login
icon inside `a[rel='phoenix_member_login']`:

```html
<a href="#" rel="phoenix_member_login" title="Anmelden">
  <div class="igreen"><img src=".../ic_login.svg"></div>
```

`enterGame()` clicked it, logged "Entered the game." and cleared its interval,
ending the search before an enter-game button had appeared. It now skips that
element and keeps looking, and gives up after 30 attempts instead of polling
every two seconds forever on a page that will never show the button.

## What the measurement also settled

**The form is an iframe, not a page.** The bare `connect.chibipass.com/` root
serves an empty document — zero inputs. The form is delivered as an iframe of
`home.html`, which the landing page holds in `#hh_game`:

```
/                                    <- landing page, enterGame() runs here
+- /home.html                        <- the game itself
   +- connect.chibipass.com/authentication/start_authentication?...
                                     <- the form, login() runs here
```

The script reaches it only because it does not declare `@noframes`. The SCOPE
block now says so, so the chibipass `@match` is not removed as unused later.

**`btn.disabled = false` was never needed to send the login.** The form is
plain server-rendered HTML — no React, no Vue, no jQuery, no `_valueTracker`
on the inputs. Setting `.value` and dispatching input/change is picked up by
the page's own validation, which then enables the submit button by itself
(measured: `disabled` goes true → false with no help from the script). The
unconditional assignment only cleared the guard the page sets *after* the
click to prevent a double submit. It is now a fallback for the case where
validation did not fire.

**`init` runs once.** A script injected at the default `@run-at document-end`
finds `readyState === "interactive"`; DOMContentLoaded has already been
dispatched, so that listener never fired (measured in all three frames). At
`document-start` both would fire and the form would be submitted twice —
measured consequence: two POSTs to `/authentication/authenticate`. `load` is
now the single start point.

## Second commit

Comment-only corrections, no executable line changed. The largest was
"Forces frameworks (React/Vue) to detect change", which claimed the opposite
of the truth: against a framework-backed input this approach fails, because
the value tracker swallows a direct `.value` assignment. Also a stale "the 100
lines below" on a file that has not been 100 lines for two versions, and
"Ignore cross-origin error" over an access that is same-origin.

Version stays at 1.3 — the second commit changes no behaviour, so what lands
is functionally the build that was tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
