### PR TITLE
fix(troll): never fight a side troll from the main adventure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.12.1 - No more troll fights the main adventure cannot open
+
+Fixes an endless loop on the troll block (issue #1875, reported by ZaryImortal).
+With **Last troll with girls** selected, the script could pick Arthur or Venam
+Kharney -- trolls that belong to a side adventure. The main adventure cannot
+open them: the game answers "Troll not available yet!", the run returns to the
+home page and picks the same troll again, every 32 seconds, without ever
+fighting.
+
+Side-troll girls now count only while the player is on that side adventure, and
+a resolved troll target that belongs to a side adventure is dropped before the
+script navigates. A fixed troll selection falls back to the last available
+troll instead; **First/Last troll with girls** skips the fight and leaves the
+turn to Love Raids. Nothing changes for players on a side adventure.
+
 ### v8.12.0 - Season can fight for the fewest points
 
 New season switch **Low points** (issue #1360, asked for by Senyor-K, scope

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.0
+// @version      8.12.1
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -29529,7 +29529,12 @@ class Troll {
                     }
                 }
             }
-            if (Object.keys(sideTrollGirlsID).length > 0) {
+            // The side-troll slots of trollGirlsID are placeholders; the real
+            // counts live in sideTrollGirlsID. Filling them in regardless of the
+            // adventure made "first/last troll with girls" pick a side troll the
+            // main adventure cannot open (issue #1875), so a main-adventure run
+            // leaves those slots at the 0 the loop above wrote.
+            if (!Troll.isMainAdventure() && Object.keys(sideTrollGirlsID).length > 0) {
                 for (const tIdx of Object.keys(sideTrollGirlsID)) {
                     trollWithGirls[Number(tIdx) - 1] = 0;
                     for (let pIdx = 0; pIdx < sideTrollGirlsID[tIdx].length; pIdx++) {
@@ -29574,8 +29579,23 @@ class Troll {
                 || getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true"
                 || LoveRaidManager.isAnyActivated());
     }
+    static isMainAdventure() {
+        return Number(getHHVars('Hero.infos.questing.choices_adventure')) === 0;
+    }
+    /**
+     * Side trolls exist only inside their side adventure. The main adventure
+     * cannot open them: the game answers with "Troll not available yet!" on a
+     * page the script does not even initialise on, so a target it keeps
+     * choosing turns into an endless home -> pre-battle -> home loop
+     * (issue #1875). sideTrollzList carries the ids; it is empty on every site
+     * except hentaiheroes.
+     */
+    static isSideTroll(trollId) {
+        const sideTrollz = ConfigHelper.getHHScriptVars("sideTrollzList");
+        return Object.prototype.hasOwnProperty.call(sideTrollz, trollId);
+    }
     static getLastTrollIdAvailable(logging = false, id_world = undefined) {
-        const isMainAdventure = Number(getHHVars('Hero.infos.questing.choices_adventure')) === 0;
+        const isMainAdventure = Troll.isMainAdventure();
         if (!id_world) {
             id_world = Number(getHHVars('Hero.infos.questing.id_world'));
         }
@@ -29778,6 +29798,15 @@ class Troll {
                 logHHAuto(`Troll ${TTF} (${trollz[Number(TTF)]}) not unlocked (last available: ${lastTrollIdAvailable}), resetting raid selector to "Choose a girl".`);
             if (allowSideEffects)
                 setStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex, "0");
+            TTF = 0;
+        }
+        // A side troll passes the unlock check above -- it sits below the last
+        // available id -- but the main adventure still cannot fight it. Events,
+        // love raids and a menu selection all reach this point, so the resolved
+        // target is checked instead of each source.
+        if (TTF > 0 && Troll.isMainAdventure() && Troll.isSideTroll(TTF)) {
+            if (logging)
+                logHHAuto(`Troll ${TTF} (${sideTrollz[Number(TTF)]}) belongs to a side adventure and cannot be fought from the main adventure.`);
             TTF = 0;
         }
         if (TTF <= 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.12.0",
+      "version": "8.12.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Troll.spec.ts
+++ b/spec/Module/Troll.spec.ts
@@ -444,6 +444,28 @@ describe("Troll module", function () {
 
             expect(Troll.getTrollWithGirls().length).toBeGreaterThan(0);
         });
+
+        // On hentaiheroes trolls 20 (Arthur) and 21 (Venam Kharney) belong to a
+        // side adventure; trollGirlsID holds placeholders for them and the real
+        // girls live in sideTrollGirlsID. Issue #1875.
+        it("leaves the side-troll slots empty on the main adventure", function () {
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(dictionaryOf(6));
+
+            const counts = Troll.getTrollWithGirls();
+
+            expect(counts[19]).toBe(0); // troll 20, Arthur
+            expect(counts[20]).toBe(0); // troll 21, Venam Kharney
+        });
+
+        it("counts the side-troll girls on a side adventure", function () {
+            unsafeWindow.shared!.Hero!.infos.questing = { id_world: 22, choices_adventure: 1 };
+            jest.spyOn(Harem, 'getGirlsList').mockReturnValue(dictionaryOf(6));
+
+            const counts = Troll.getTrollWithGirls();
+
+            expect(counts[19]).toBe(4); // troll 20: four girls, none owned
+            expect(counts[20]).toBe(3); // troll 21: three girls, none owned
+        });
     });
 
     describe("getTrollIdToFight", function () {
@@ -581,6 +603,43 @@ describe("Troll module", function () {
             // With logging=true, autoTrollBattleSaveQuest overrides to lastTrollIdAvailable
             const TTF = Troll.getTrollIdToFight(true);
             expect(TTF).toBe(4);
+        });
+
+        // Issue #1875: on world 24 the last available troll is 22, so a side
+        // troll (20, 21) passes the unlock check. Navigating there gets
+        // "Troll not available yet!" from the game and the run loops.
+        describe("side trolls on the main adventure", function () {
+            const world24 = () => {
+                unsafeWindow.shared!.Hero!.infos.questing = { id_world: 24, choices_adventure: 0 };
+            };
+
+            it("does not pick a side troll left over in a trollWithGirls snapshot", function () {
+                world24();
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '99');
+                // The snapshot from the reported log: troll 22 is finished, the
+                // last non-zero slot is troll 21, a side troll.
+                jest.spyOn(Troll, 'getTrollWithGirls').mockReturnValue(
+                    [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 3, 0]);
+
+                expect(Troll.getTrollIdToFight(false)).toBe(0);
+            });
+
+            it("falls back to the last available troll when a side troll is selected in the menu", function () {
+                world24();
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '21');
+
+                expect(Troll.getTrollIdToFight(false)).toBe(22);
+            });
+
+            it("keeps the side troll while the player is on that side adventure", function () {
+                unsafeWindow.shared!.Hero!.infos.questing = { id_world: 23, choices_adventure: 1 };
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
+                localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '21');
+
+                expect(Troll.getTrollIdToFight(false)).toBe(21);
+            });
         });
 
         it("falls back to 1 when autoTrollBattle enabled but troll not in trollzList", function () {

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -91,7 +91,12 @@ export class Troll {
                 }
             }
 
-            if (Object.keys(sideTrollGirlsID).length > 0) {
+            // The side-troll slots of trollGirlsID are placeholders; the real
+            // counts live in sideTrollGirlsID. Filling them in regardless of the
+            // adventure made "first/last troll with girls" pick a side troll the
+            // main adventure cannot open (issue #1875), so a main-adventure run
+            // leaves those slots at the 0 the loop above wrote.
+            if (!Troll.isMainAdventure() && Object.keys(sideTrollGirlsID).length > 0) {
                 for (const tIdx of Object.keys(sideTrollGirlsID)) {
                     trollWithGirls[Number(tIdx)-1] = 0;
                     for (let pIdx = 0; pIdx < sideTrollGirlsID[tIdx].length; pIdx++) {
@@ -142,8 +147,25 @@ export class Troll {
         )
     }
 
+    static isMainAdventure(): boolean {
+        return Number(getHHVars('Hero.infos.questing.choices_adventure')) === 0;
+    }
+
+    /**
+     * Side trolls exist only inside their side adventure. The main adventure
+     * cannot open them: the game answers with "Troll not available yet!" on a
+     * page the script does not even initialise on, so a target it keeps
+     * choosing turns into an endless home -> pre-battle -> home loop
+     * (issue #1875). sideTrollzList carries the ids; it is empty on every site
+     * except hentaiheroes.
+     */
+    static isSideTroll(trollId: number): boolean {
+        const sideTrollz = ConfigHelper.getHHScriptVars("sideTrollzList");
+        return Object.prototype.hasOwnProperty.call(sideTrollz, trollId);
+    }
+
     static getLastTrollIdAvailable(logging = false, id_world: number = undefined as any): number {
-        const isMainAdventure = Number(getHHVars('Hero.infos.questing.choices_adventure')) === 0;
+        const isMainAdventure = Troll.isMainAdventure();
         if (!id_world) {
             id_world = Number(getHHVars('Hero.infos.questing.id_world'));
         } else if (id_world <= 0) {
@@ -327,6 +349,15 @@ export class Troll {
         if (TTF > 0 && TTF > lastTrollIdAvailable) {
             if (logging) logHHAuto(`Troll ${TTF} (${trollz[Number(TTF)]}) not unlocked (last available: ${lastTrollIdAvailable}), resetting raid selector to "Choose a girl".`);
             if (allowSideEffects) setStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex, "0");
+            TTF = 0;
+        }
+
+        // A side troll passes the unlock check above -- it sits below the last
+        // available id -- but the main adventure still cannot fight it. Events,
+        // love raids and a menu selection all reach this point, so the resolved
+        // target is checked instead of each source.
+        if (TTF > 0 && Troll.isMainAdventure() && Troll.isSideTroll(TTF)) {
+            if (logging) logHHAuto(`Troll ${TTF} (${sideTrollz[Number(TTF)]}) belongs to a side adventure and cannot be fought from the main adventure.`);
             TTF = 0;
         }
 


### PR DESCRIPTION
Refs #1875.

With **Last troll with girls** selected, the troll target could land on Arthur (20) or Venam Kharney (21). Both belong to a side adventure; the main adventure cannot open them, so the game answers "Troll not available yet!" on a page the script does not initialise on. The run falls back to the home page and picks the same troll again every 32 seconds without ever fighting. On world 24 the last available id is 22, so the existing unlock check let them through.

## Changes

- `getTrollWithGirls()` merged `sideTrollGirlsID` into the placeholder slots of `trollGirlsID` regardless of the adventure — that is where the target came from. It now does so only on a side adventure.
- `getTrollIdToFight()` drops a resolved side-troll target while on the main adventure, which also covers events, love raids and a menu selection.
- `isMainAdventure()` and `isSideTroll()` extracted; the first was a local constant in `getLastTrollIdAvailable`.

Behaviour after the fix: First/Last troll with girls skips the fight and leaves the turn to Love Raids; a fixed troll selection falls back to the last available troll. Nothing changes on a side adventure. Only hentaiheroes defines side trolls.

## Tests

Five new cases in `spec/Module/Troll.spec.ts`, three of which fail without the fix. One replays the `trollWithGirls` snapshot from the reported log.

All gates green: typecheck, lint:ci, 1493 tests, deps:circular:check, check:gm-grants, check:docs, check:headers, check:player-data, build.

## Not done here

No generic guard against "Troll not available yet". The script does not initialise on that page ("Not a game page"), so it cannot see the error there. A guard would need its own counter state — target remembered, return to home without a fight, target blocked — with false positives from mouse pause and manual navigation. Separate ticket if wanted.

`HHMenuHelper.fillTrollSelectMenu` still lists side trolls under the "Side adventure" separator regardless of the current adventure. Selecting one on the main adventure is now silently redirected to the last available troll, visible in the log.