### PR TITLE
fix(booster): stop recording a refused Sandalwood equip as worn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.12.2 - A refused Sandalwood equip is no longer recorded as worn
+
+Fixes Sandalwood staying off for the rest of a session (issue #1874, reported
+by fincogneato). When the game refused the equip -- all five mythic slots
+taken, or the request timing out -- the script wrote the perfume into its
+equipped-booster state anyway, to stop it retrying. From that point it believed
+Sandalwood was on: it never asked again, and it never reached the third refusal
+that would have told the player something was wrong. The retry spam is held off
+by the five-minute cooldown that was already there, so the state is now left
+alone and the next attempt happens once that cooldown passes.
+
+Two things around it:
+
+- The dose count assumed for a perfume the script could not read was a flat 99,
+  about twenty times a real one. The re-equip that triggers at zero doses waited
+  that many troll fights. The last count actually seen on an equip is used now.
+- Three refused Sandalwood equips switch the +Event / +Mythic / +Raid Sandalwood
+  setting off. Every booster counted into that total, so a Mythic Slot entry the
+  game rejects as conflicting could switch off an unrelated setting. Only a
+  refused Sandalwood counts now.
+
 ### v8.12.1 - No more troll fights the main adventure cannot open
 
 Fixes an endless loop on the troll block (issue #1875, reported by ZaryImortal).

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.1
+// @version      8.12.2
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -7987,6 +7987,12 @@ class HeroHelper {
                 id_item: itemId,
                 type: "booster"
             };
+            // sandalwoodFailure counts refused Sandalwood equips, and three of them
+            // switch the user's +Event/+Mythic/+Raid Sandalwood setting off. Every
+            // booster used to count into it, so a mythic-list entry the game
+            // refuses as conflicting could turn off an unrelated setting
+            // (issue #1874).
+            const countsAsSandalwoodFailure = booster.identifier === 'MB1';
             return new Promise((resolve) => {
                 // change referer
                 const currentPath = window.location.href.replace('http://', '').replace('https://', '').replace(window.location.hostname, '');
@@ -8014,7 +8020,8 @@ class HeroHelper {
                     // Treat a hang as "state unknown": drop the freshness stamp so the next
                     // auto-equip cycle re-reads boosterStatus from the market.
                     deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                    HeroHelper.getSandalWoodEquipFailure(true);
+                    if (countsAsSandalwoodFailure)
+                        HeroHelper.getSandalWoodEquipFailure(true);
                     settle(false);
                 }, 15000);
                 getHHAjax()(params, function (data) {
@@ -8029,7 +8036,8 @@ class HeroHelper {
                         // boosters while we were paused). Invalidate the freshness timestamp
                         // so autoEquipBoosters refreshes from the market before retrying.
                         deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                        HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
+                        if (countsAsSandalwoodFailure)
+                            HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                     }
                     logHHAuto(`equipBooster: resolving with ${data.success}`);
                     settle(!!data.success);
@@ -8037,7 +8045,8 @@ class HeroHelper {
                     logHHAuto('equipBooster: AJAX error callback - ' + err);
                     // Network/server error also implies our cached state may be wrong — invalidate.
                     deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                    HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
+                    if (countsAsSandalwoodFailure)
+                        HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                     logHHAuto('equipBooster: resolving with false');
                     settle(false);
                 });
@@ -13129,6 +13138,25 @@ class Booster {
         setTimer('nextBoosterEquipTime', seconds);
         logHHAuto(`Booster equip cooldown set for ${seconds} seconds`);
     }
+    /**
+     * Doses to assume for a mythic booster whose real count is not in hand.
+     *
+     * A mythic booster is spent per use, not per hour, and only the market
+     * scrape and the equip response carry the real number. A flat 99 was
+     * written for every one of them, which for Sandalwood is wrong by about a
+     * factor of twenty: getSandalwoodDosesRemaining() then reports a stock the
+     * player does not have, and the depletion check that re-equips at 0 doses
+     * waits ~99 troll fights (issue #1874). The last count seen on an equip is
+     * kept in sandalwoodMaxUsages precisely for this; a fresh perfume is worth
+     * that many doses. Without it the old 99 stands, and the next market visit
+     * corrects it either way.
+     */
+    static assumedMythicUsages(identifier) {
+        if (identifier !== Booster.SANDALWOOD_IDENTIFIER)
+            return 99;
+        const known = Number(getStoredValue(HHStoredVarPrefixKey + TK.sandalwoodMaxUsages));
+        return Number.isFinite(known) && known > 0 ? known : 99;
+    }
     static markBoosterAsEquippedInStorage(booster) {
         const boosterStatus = Booster.getBoosterFromStorage();
         const isMythic = booster.rarity === 'mythic' || (booster.identifier && booster.identifier.startsWith('MB'));
@@ -13137,7 +13165,7 @@ class Booster {
             if (!alreadyTracked) {
                 boosterStatus.mythic.push({
                     item: booster,
-                    usages_remaining: 99 // Unknown, will be refreshed on next market visit
+                    usages_remaining: Booster.assumedMythicUsages(booster.identifier)
                 });
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(boosterStatus));
                 // Restore the freshness stamp that equipBooster cleared on
@@ -13340,10 +13368,16 @@ class Booster {
                             setStoredValue(HHStoredVarPrefixKey + settingKey, 'false');
                         }
                         else {
-                            logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: marking as already equipped + setting cooldown");
-                            // Server says max boosters equipped - mark it as equipped to prevent retries
-                            Booster.markBoosterAsEquippedInStorage(sandalwoodBooster);
-                            // Set cooldown to prevent spamming equip attempts
+                            logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: setting cooldown after failure #" + numberFailure);
+                            // The cooldown is what stops the retry spam. Writing the
+                            // perfume into boosterStatus as if it were on did that
+                            // too, and much harder: haveBoosterEquiped('MB1') then
+                            // answered true, so needSandalWoodEquipped() returned
+                            // false from there on and no later attempt was ever
+                            // made -- the counter never reached the third failure
+                            // either (issue #1874). It also stamped
+                            // boosterStatusLastUpdate, which kept the market visit
+                            // that would have corrected the lie from happening.
                             Booster.setEquipCooldown(5 * 60);
                         }
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.12.1",
+  "version": "8.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.12.1",
+      "version": "8.12.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.1",
+  "version": "8.12.2",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Helper/HeroHelper.spec.ts
+++ b/spec/Helper/HeroHelper.spec.ts
@@ -137,7 +137,7 @@ describe("HeroHelper", function() {
         mockEquipeResponse(false);
       const boosters = '{"B1":10,"B2":0,"B3":0,"B4":0,"MB1":10,"MB2":0,"MB3":0,"MB4":0}';
       sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_haveBooster", boosters);
-      const result1 = await HeroHelper.equipBooster(TEST_GINSENG);
+      const result1 = await HeroHelper.equipBooster(TEST_SANDALWOOD);
       expect(result1).toBeFalsy();
       // Failure counter should increase
       expect(HeroHelper.getSandalWoodEquipFailure()).toBe(1);
@@ -147,10 +147,34 @@ describe("HeroHelper", function() {
         mockEquipeError();
       const boosters = '{"B1":10,"B2":0,"B3":0,"B4":0,"MB1":10,"MB2":0,"MB3":0,"MB4":0}';
       sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_haveBooster", boosters);
-      const result = await HeroHelper.equipBooster(TEST_GINSENG);
+      const result = await HeroHelper.equipBooster(TEST_SANDALWOOD);
       expect(result).toBeFalsy();
       // Failure counter should increase on AJAX error too
       expect(HeroHelper.getSandalWoodEquipFailure()).toBe(1);
+    });
+
+    // Three counted failures switch the user's Sandalwood setting off, so only
+    // a refused Sandalwood may count -- a mythic-list entry the game rejects as
+    // conflicting must not disable an unrelated setting (issue #1874).
+    it("a failure on another booster leaves the Sandalwood counter alone", async function() {
+        mockEquipeResponse(false);
+      const boosters = '{"B1":10,"B2":0,"B3":0,"B4":0,"MB1":10,"MB2":0,"MB3":0,"MB4":0}';
+      sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_haveBooster", boosters);
+
+      const result = await HeroHelper.equipBooster(TEST_GINSENG);
+
+      expect(result).toBeFalsy();
+      expect(HeroHelper.getSandalWoodEquipFailure()).toBe(0);
+    });
+
+    it("an AJAX error on another booster leaves the Sandalwood counter alone", async function() {
+        mockEquipeError();
+      const boosters = '{"B1":10,"B2":0,"B3":0,"B4":0,"MB1":10,"MB2":0,"MB3":0,"MB4":0}';
+      sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_haveBooster", boosters);
+
+      await HeroHelper.equipBooster(TEST_GINSENG);
+
+      expect(HeroHelper.getSandalWoodEquipFailure()).toBe(0);
     });
 
     it("Multiple failures increment counter", async function() {

--- a/spec/Module/Booster.spec.ts
+++ b/spec/Module/Booster.spec.ts
@@ -208,6 +208,30 @@ describe("Booster", function() {
       expect(Booster.haveBoosterEquiped('MB1')).toBeTruthy();
     });
 
+    // A flat 99 for the perfume is a stock the player does not have: the
+    // depletion check that re-equips at 0 doses then waits ~99 fights (#1874).
+    it("uses the last Sandalwood dose count seen instead of the flat 99", function() {
+      sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_sandalwoodMaxUsages", '5');
+
+      Booster.markBoosterAsEquippedInStorage(TEST_SANDALWOOD);
+
+      expect(Booster.getSandalwoodDosesRemaining()).toBe(5);
+    });
+
+    it("keeps the 99 for Sandalwood while no dose count has been seen", function() {
+      Booster.markBoosterAsEquippedInStorage(TEST_SANDALWOOD);
+
+      expect(Booster.getSandalwoodDosesRemaining()).toBe(99);
+    });
+
+    it("keeps the 99 for other mythic boosters", function() {
+      sessionStorage.setItem(HHStoredVarPrefixKey+"Temp_sandalwoodMaxUsages", '5');
+
+      Booster.markBoosterAsEquippedInStorage({id_item: "640", identifier: "MB6", name: "Alban's travel memories", rarity: "mythic"});
+
+      expect(Booster.getBoosterFromStorage().mythic[0].usages_remaining).toBe(99);
+    });
+
     it("marks normal booster as equipped", function() {
       Booster.markBoosterAsEquippedInStorage(TEST_GINSENG);
       const status = Booster.getBoosterFromStorage();
@@ -431,10 +455,23 @@ describe("Booster", function() {
         expect(HeroHelper.getSandalWoodEquipFailure()).toBe(1);
         // Setting should still be active
         expect(localStorage.getItem(HHStoredVarPrefixKey+"Setting_plusEventMythicSandalWood")).toBe('true');
-        // Booster should be marked as equipped in storage
-        expect(Booster.haveBoosterEquiped('MB1')).toBeTruthy();
+        // A refused equip must not be recorded as equipped: that answer feeds
+        // needSandalWoodEquipped(), which would then never ask again (#1874).
+        expect(Booster.haveBoosterEquiped('MB1')).toBeFalsy();
         // Cooldown should be set
         expect(Booster.isEquipOnCooldown()).toBeTruthy();
+      });
+
+      it("asks again once the cooldown has passed (issue #1874)", async function() {
+        setGirl(true, 99, 55);
+        localStorage.setItem(HHStoredVarPrefixKey+"Setting_plusEventMythic", 'true');
+        localStorage.setItem(HHStoredVarPrefixKey+"Setting_plusEventMythicSandalWood", 'true');
+
+        await Booster.equipeSandalWoodIfNeeded(99);
+        expect(Booster.needSandalWoodEquipped(99)).toBeFalsy(); // still on cooldown
+
+        clearTimer('nextBoosterEquipTime');
+        expect(Booster.needSandalWoodEquipped(99)).toBeTruthy();
       });
 
       it("Third failure deactivates setting", async function() {

--- a/src/Helper/HeroHelper.ts
+++ b/src/Helper/HeroHelper.ts
@@ -161,6 +161,13 @@ export class HeroHelper {
             type: "booster"
         };
 
+        // sandalwoodFailure counts refused Sandalwood equips, and three of them
+        // switch the user's +Event/+Mythic/+Raid Sandalwood setting off. Every
+        // booster used to count into it, so a mythic-list entry the game
+        // refuses as conflicting could turn off an unrelated setting
+        // (issue #1874).
+        const countsAsSandalwoodFailure = booster.identifier === 'MB1';
+
         return new Promise((resolve) => {
             // change referer
             const currentPath = window.location.href.replace('http://', '').replace('https://', '').replace(window.location.hostname, '');
@@ -187,7 +194,7 @@ export class HeroHelper {
                 // Treat a hang as "state unknown": drop the freshness stamp so the next
                 // auto-equip cycle re-reads boosterStatus from the market.
                 deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                HeroHelper.getSandalWoodEquipFailure(true);
+                if (countsAsSandalwoodFailure) HeroHelper.getSandalWoodEquipFailure(true);
                 settle(false);
             }, 15000);
 
@@ -202,7 +209,7 @@ export class HeroHelper {
                     // boosters while we were paused). Invalidate the freshness timestamp
                     // so autoEquipBoosters refreshes from the market before retrying.
                     deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                    HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
+                    if (countsAsSandalwoodFailure) HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                 }
                 logHHAuto(`equipBooster: resolving with ${data.success}`);
                 settle(!!data.success);
@@ -210,7 +217,7 @@ export class HeroHelper {
                 logHHAuto('equipBooster: AJAX error callback - ' + err);
                 // Network/server error also implies our cached state may be wrong — invalidate.
                 deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
-                HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
+                if (countsAsSandalwoodFailure) HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                 logHHAuto('equipBooster: resolving with false');
                 settle(false);
             });

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -998,6 +998,25 @@ export class Booster {
         logHHAuto(`Booster equip cooldown set for ${seconds} seconds`);
     }
 
+    /**
+     * Doses to assume for a mythic booster whose real count is not in hand.
+     *
+     * A mythic booster is spent per use, not per hour, and only the market
+     * scrape and the equip response carry the real number. A flat 99 was
+     * written for every one of them, which for Sandalwood is wrong by about a
+     * factor of twenty: getSandalwoodDosesRemaining() then reports a stock the
+     * player does not have, and the depletion check that re-equips at 0 doses
+     * waits ~99 troll fights (issue #1874). The last count seen on an equip is
+     * kept in sandalwoodMaxUsages precisely for this; a fresh perfume is worth
+     * that many doses. Without it the old 99 stands, and the next market visit
+     * corrects it either way.
+     */
+    static assumedMythicUsages(identifier: string): number {
+        if (identifier !== Booster.SANDALWOOD_IDENTIFIER) return 99;
+        const known = Number(getStoredValue(HHStoredVarPrefixKey + TK.sandalwoodMaxUsages));
+        return Number.isFinite(known) && known > 0 ? known : 99;
+    }
+
     static markBoosterAsEquippedInStorage(booster: any) {
         const boosterStatus = Booster.getBoosterFromStorage();
         const isMythic = booster.rarity === 'mythic' || (booster.identifier && booster.identifier.startsWith('MB'));
@@ -1007,7 +1026,7 @@ export class Booster {
             if (!alreadyTracked) {
                 boosterStatus.mythic.push({
                     item: booster,
-                    usages_remaining: 99 // Unknown, will be refreshed on next market visit
+                    usages_remaining: Booster.assumedMythicUsages(booster.identifier)
                 });
                 setStoredValue(HHStoredVarPrefixKey+TK.boosterStatus, JSON.stringify(boosterStatus));
                 // Restore the freshness stamp that equipBooster cleared on
@@ -1207,10 +1226,16 @@ export class Booster {
                         logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: 3rd failure, deactivating auto sandalwood settingKey=" + settingKey);
                         setStoredValue(HHStoredVarPrefixKey + settingKey, 'false');
                     } else {
-                        logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: marking as already equipped + setting cooldown");
-                        // Server says max boosters equipped - mark it as equipped to prevent retries
-                        Booster.markBoosterAsEquippedInStorage(sandalwoodBooster);
-                        // Set cooldown to prevent spamming equip attempts
+                        logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: setting cooldown after failure #" + numberFailure);
+                        // The cooldown is what stops the retry spam. Writing the
+                        // perfume into boosterStatus as if it were on did that
+                        // too, and much harder: haveBoosterEquiped('MB1') then
+                        // answered true, so needSandalWoodEquipped() returned
+                        // false from there on and no later attempt was ever
+                        // made -- the counter never reached the third failure
+                        // either (issue #1874). It also stamped
+                        // boosterStatusLastUpdate, which kept the market visit
+                        // that would have corrected the lie from happening.
                         Booster.setEquipCooldown(5 * 60);
                     }
                 } else {


### PR DESCRIPTION
Refs #1874.

When the game refused the Sandalwood equip — five mythic slots taken, or the 15s request timeout — `equipeSandalWoodIfNeeded` wrote the perfume into `boosterStatus` anyway, with the comment "mark it as equipped to prevent retries". From that point `haveBoosterEquiped('MB1')` answered true, so `ownedSandalwoodAndNotEquiped()` and with it `needSandalWoodEquipped()` returned false: no later attempt was made, and the failure counter never reached the third refusal that switches the setting off. The stamp it set on `boosterStatusLastUpdate` also kept the market visit that would have corrected the entry from happening.

That matches the reporter's third observation — the dose count only became correct after manually opening the equipment page, which is where `collectBoostersFromMarket()` reads the real value.

The five-minute cooldown right next to it already holds off the retries, so the state is left alone now and the next attempt comes when the cooldown expires.

## Also in here

Both are reachable from the same failure path and would have been left as traps by the fix alone.

- `markBoosterAsEquippedInStorage` assumed a flat 99 doses for any mythic booster whose real count it did not have. For the perfume that is out by roughly a factor of twenty, and the depletion check that re-equips at 0 doses waited that many troll fights. `TK.sandalwoodMaxUsages` holds the last count seen on an equip and was written but never read anywhere; it is used now, with 99 as the fallback and for every other mythic booster.
- The Sandalwood failure counter was incremented by *every* booster equip failure in `HeroHelper.equipBooster`. Three of them switch the user's +Event/+Mythic/+Raid Sandalwood setting off, so a Mythic Slot entry the game rejects as conflicting could disable an unrelated setting. Only MB1 counts now. Without this, removing the mark-as-equipped would have made that path reachable for the first time.

## Tests

Five new or corrected cases across `spec/Module/Booster.spec.ts` and `spec/Helper/HeroHelper.spec.ts`; all five fail without the fix. Two existing tests pinned the old behaviour and were updated — one of them had a `// Clear the booster status so ownedSandalwoodAndNotEquiped() returns true` line that only existed to work around this bug.

All gates green: typecheck, lint:ci, 1499 tests, deps:circular:check, check:gm-grants, check:docs, check:headers, check:player-data, build.

## Not covered

Both debug logs on the issue have expired (tmpfiles.org, 48h), so the reporter's first scenario — Sandalwood not applied during a running Mythic event — is not confirmed to be this path. `needSandalWoodMythic` also requires the chosen troll to be the mythic girl's troll, which is a separate reason for the same symptom. A fresh log is being requested on the issue.