### PR TITLE
fix(booster): keep shop payloads out of the equipped-booster state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.12.3 - The market scrape no longer files a shop entry as an equipped booster
+
+Fixes Sandalwood never being replaced once it runs out (issue #1874, reported
+by fincogneato).
+
+The market page carries two families of elements with the same
+`slot ... mythic` classes: the boosters you have on, and the ones in your
+inventory below them. They differ in their payload -- an equipped one carries
+the id of its equip row and a remaining-uses count, an inventory one carries a
+buy price and no count at all. The scrape that records what is equipped went by
+the classes alone, and in the reported log it filed an inventory entry for
+Sandalwood one and a half seconds after a fresh perfume had been equipped.
+
+From there the script believed the perfume was on and could not be told
+otherwise. The check that re-equips at zero doses compares the count against
+zero, and a missing count is neither a number nor null, so it passed straight
+through. The perfume ran out and nothing replaced it for the rest of the
+session.
+
+The scrape now takes only payloads that are actually equipped boosters, a
+missing dose count reads as "unknown" instead of "plenty", and an entry that
+cannot say how many doses are left is dropped so the perfume is equipped again.
+An account already carrying such an entry recovers on the next pass.
+
 ### v8.12.2 - A refused Sandalwood equip is no longer recorded as worn
 
 Fixes Sandalwood staying off for the rest of a session (issue #1874, reported

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.2
+// @version      8.12.3
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -12513,10 +12513,33 @@ class Booster {
                 || boosterStatus.normal.some((booster) => booster.item.identifier === boosterCode && booster.endAt > serverNow);
         }
     }
+    /**
+     * An equipped booster carries the id of its equip row. The market page
+     * serves a second family of elements with the very same `slot ... mythic`
+     * classes under `#player-inventory-booster` -- the ones you can buy or
+     * equip -- and those payloads have `price_buy` and no `usages_remaining`.
+     *
+     * Measured on the live market page: the three equipped slots all carry
+     * `id_member_booster_equipped`, `lifetime`, `expiration` and
+     * `usages_remaining`; the five inventory entries carry `price_buy` and
+     * none of those. An inventory payload that reaches boosterStatus makes
+     * haveBoosterEquiped() answer true for a booster that is not on, and the
+     * dose count is then missing rather than zero -- so the depletion check
+     * (`<= 0`) never fires and Sandalwood is never re-equipped (issue #1874).
+     */
+    static isEquippedBoosterPayload(data) {
+        return !!data && data.id_member_booster_equipped !== undefined && data.id_member_booster_equipped !== null;
+    }
     static collectBoostersFromMarket() {
-        const activeSlots = $('#equiped .booster .slot:not(.empty):not(.mythic)').map((i, el) => $(el).data('d')).toArray();
-        const activeMythicSlots = $('#equiped .booster .slot:not(.empty).mythic').map((i, el) => $(el).data('d')).toArray();
+        const rawSlots = $('#equiped .booster .slot:not(.empty):not(.mythic)').map((i, el) => $(el).data('d')).toArray();
+        const rawMythicSlots = $('#equiped .booster .slot:not(.empty).mythic').map((i, el) => $(el).data('d')).toArray();
+        const activeSlots = rawSlots.filter(Booster.isEquippedBoosterPayload);
+        const activeMythicSlots = rawMythicSlots.filter(Booster.isEquippedBoosterPayload);
+        const dropped = (rawSlots.length - activeSlots.length) + (rawMythicSlots.length - activeMythicSlots.length);
         logHHAuto(`collectBoostersFromMarket: found ${activeSlots.length} normal boosters, ${activeMythicSlots.length} mythic boosters equipped`);
+        if (dropped > 0) {
+            logHHAuto(`collectBoostersFromMarket: ignored ${dropped} slot payload(s) that are not equipped boosters`);
+        }
         const boosterStatus = {
             normal: activeSlots.map((data) => (Object.assign(Object.assign({}, data), { endAt: getHHVars('server_now_ts') + data.expiration }))),
             mythic: activeMythicSlots,
@@ -13111,16 +13134,26 @@ class Booster {
             needForLoveRaid = Booster.needSandalWoodLoveRaid(nextTrollChoosen, loveRaid);
         }
         logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
-        // Proactive depletion check: if Sandalwood is equipped but has 0 doses remaining,
-        // remove it from boosterStatus so ownedSandalwoodAndNotEquiped() triggers re-equip.
+        // Drop the Sandalwood entry when it is spent, and equally when it cannot
+        // say how much is left: ownedSandalwoodAndNotEquiped() then reports it as
+        // not equipped and the equip path runs. An entry without a dose count is
+        // what an inventory payload looks like once it has been scraped into
+        // boosterStatus, and leaving it there is what kept the perfume off for
+        // the rest of a session (issue #1874).
         if (needForEvent || needForMythic || needForLoveRaid) {
             const dosesRemaining = Booster.getSandalwoodDosesRemaining();
-            logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}`);
-            if (dosesRemaining !== null && dosesRemaining <= 0) {
-                logHHAuto('needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
+            const untrustworthy = Booster.hasUntrustworthySandalwoodEntry();
+            logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}, untrustworthy=${untrustworthy}`);
+            if (untrustworthy || (dosesRemaining !== null && dosesRemaining <= 0)) {
+                logHHAuto(untrustworthy
+                    ? 'needSandalWoodEquipped: Sandalwood entry carries no dose count, dropping it to trigger re-equip'
+                    : 'needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
                 const boosterStatus = Booster.getBoosterFromStorage();
                 boosterStatus.mythic = boosterStatus.mythic.filter(b => { var _a; return ((_a = b.item) === null || _a === void 0 ? void 0 : _a.identifier) !== 'MB1'; });
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(boosterStatus));
+                // The stored status no longer matches the market: let the next
+                // autoEquipBoosters pass refresh it instead of trusting this one.
+                deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
             }
         }
         return ((needForEvent || needForMythic || needForLoveRaid) && Booster.ownedSandalwoodAndNotEquiped());
@@ -13399,15 +13432,34 @@ class Booster {
         });
     }
     /**
-     * Returns the number of remaining Sandalwood doses from boosterStatus.
-     * Returns null if Sandalwood is not currently equipped.
+     * Remaining Sandalwood doses, or null when there is no number to give:
+     * Sandalwood is not tracked as equipped, or its entry carries no usable
+     * count.
+     *
+     * The raw field used to be returned as it stood. An entry without one then
+     * yielded `undefined`, and the caller's `dosesRemaining !== null &&
+     * dosesRemaining <= 0` let it through the first test and failed the second
+     * -- a missing count read as "plenty left" (issue #1874). A count is a
+     * number here or it is null, and null means "ask the market", not "fine".
      */
     static getSandalwoodDosesRemaining() {
         const boosterStatus = Booster.getBoosterFromStorage();
         const sandalwood = boosterStatus.mythic.find(b => { var _a; return ((_a = b.item) === null || _a === void 0 ? void 0 : _a.identifier) === 'MB1'; });
         if (!sandalwood)
             return null;
-        return sandalwood.usages_remaining;
+        const doses = Number(sandalwood.usages_remaining);
+        return Number.isFinite(doses) ? doses : null;
+    }
+    /**
+     * True when Sandalwood is tracked as equipped but its entry cannot say how
+     * many doses are left. The entry is then not trustworthy -- it is what an
+     * inventory payload scraped into boosterStatus looks like -- and the
+     * caller drops it so the equip path runs again (issue #1874).
+     */
+    static hasUntrustworthySandalwoodEntry() {
+        const boosterStatus = Booster.getBoosterFromStorage();
+        const sandalwood = boosterStatus.mythic.find(b => { var _a; return ((_a = b.item) === null || _a === void 0 ? void 0 : _a.identifier) === 'MB1'; });
+        return !!sandalwood && Booster.getSandalwoodDosesRemaining() === null;
     }
 }
 /** Sandalwood identifier constant — id_item is resolved from market data or env config at runtime. */

--- a/docs-internal/data-sources-inventory.md
+++ b/docs-internal/data-sources-inventory.md
@@ -260,6 +260,29 @@ Felder im JSON: `quantity`, `item.{id_item, type, identifier, rarity, price, cur
 | `#shops div.booster.player-inventory-content .slot` | `{quantity, item:{id_item, identifier, name, rarity}}` | Shop | `Module/Shop.ts` | `Shop.collectShopFromMarket()` (HaveBooster + BoosterIdMap) |
 | `#equiped .booster .slot:not(.empty):not(.mythic)` (jQ `.data('d')`) | Normal-Booster-Slot (mit `expiration`) | Shop | `Module/Booster.ts` | `Booster.collectBoostersFromMarket()` |
 | `#equiped .booster .slot:not(.empty).mythic` (jQ `.data('d')`) | Mythic-Booster-Slot (mit `usages_remaining`, `lifetime`) | Shop | `Module/Booster.ts` | `Booster.collectBoostersFromMarket()` |
+
+**Gemessen (2026-09-07, laufende Marktseite):** Die Marktseite traegt die Klassen
+`slot ... mythic` an **zwei** Element-Familien, die sich nur am Vorfahren
+unterscheiden -- getragen unter `#equiped`, besitzt-aber-nicht-getragen unter
+`#player-inventory-booster`. Die Nutzlasten sind verschieden:
+
+| | getragen (`#equiped`) | Inventar (`#player-inventory-booster`) |
+| --- | --- | --- |
+| Schluessel | `id_member_booster_equipped`, `lifetime`, `expiration`, `usages_remaining`, `price_sell` | `price_buy`, `price_sell`, `id_item`, `id_member` |
+| Dosenzahl | vorhanden | **fehlt ganz** |
+
+Dieselbe Falle wie bei der Ruestung weiter oben: der Unterschied ist der
+`..._equipped`-Schluessel, nicht die Klasse. Ein Inventar-Eintrag in
+`boosterStatus` laesst `haveBoosterEquiped()` true sagen fuer einen Booster, der
+nicht anliegt, und die fehlende Dosenzahl ist weder eine Zahl noch `null` --
+`<= 0` greift dann nie (Issue #1874). `collectBoostersFromMarket()` filtert
+seit 8.12.3 auf `id_member_booster_equipped`.
+
+Die volle Dosenzahl steht als `item.default_usages` in derselben Nutzlast
+(gemessen: MB1 11, MB2 100, MB5 100). Das Spiel selbst faellt darauf zurueck,
+wenn `usages_remaining` fehlt oder 0 ist -- in `shared.js`:
+`t.usages_remaining&&t.usages_remaining>0?t.usages_remaining:t.item.default_usages`.
+
 | `#player-inventory.armor .slot:not(.empty)[data-d*='"rarity":"mythic"']` (Selector-Inhalts-Match) | Filter ueber Substring-Match in `data-d` | Shop | `Module/Shop.ts` | `Shop.moduleShopActions()` |
 | `[data-d*='"name_add":<X>']` (dyn. Filter) | Filter nach Stat | Shop | `Module/Shop.ts` | `Shop.moduleShopActions()` / `setSlotFilter()` |
 | `[data-d*='"subtype":<X>']` (dyn. Filter) | Filter nach Item-Subtyp | Shop | `Module/Shop.ts` | `Shop.moduleShopActions()` / `setSlotFilter()` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.12.2",
+      "version": "8.12.3",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Booster.spec.ts
+++ b/spec/Module/Booster.spec.ts
@@ -257,6 +257,79 @@ describe("Booster", function() {
     });
   });
 
+  // Payload shapes taken from the live market page: an equipped slot carries
+  // id_member_booster_equipped, lifetime, expiration and usages_remaining; an
+  // inventory entry under #player-inventory-booster carries price_buy and none
+  // of those, while wearing the very same `slot ... mythic` classes.
+  describe("collectBoostersFromMarket -- only equipped payloads (issue #1874)", function() {
+    const EQUIPPED_MB1 = {
+      id_member_booster_equipped: 55057495, id_item: 632, id_member: 1,
+      lifetime: 1788611091, expiration: 75945, price_sell: 16500, usages_remaining: 5,
+      item: { id_item: 632, identifier: 'MB1', name: 'Sandalwood perfume', rarity: 'mythic', default_usages: 11 },
+    };
+    const INVENTORY_MB1 = {
+      id_item: 632, id_member: 1, price_buy: 900, price_sell: 16500,
+      item: { id_item: 632, identifier: 'MB1', name: 'Sandalwood perfume', rarity: 'mythic', default_usages: 11 },
+    };
+
+    const renderSlots = (mythic: object[]) => {
+      document.body.innerHTML = '<div id="equiped"><div class="booster"></div></div>';
+      const holder = document.querySelector('#equiped .booster')!;
+      for (const d of mythic) {
+        const el = document.createElement('div');
+        el.className = 'slot size_small slot_market mythic';
+        holder.appendChild(el);
+        $(el).data('d', d);
+      }
+    };
+
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    it("keeps an equipped payload", function() {
+      renderSlots([EQUIPPED_MB1]);
+
+      Booster.collectBoostersFromMarket();
+
+      expect(Booster.getBoosterFromStorage().mythic.length).toBe(1);
+      expect(Booster.getSandalwoodDosesRemaining()).toBe(5);
+    });
+
+    it("ignores an inventory payload wearing the same classes", function() {
+      renderSlots([INVENTORY_MB1]);
+
+      Booster.collectBoostersFromMarket();
+
+      expect(Booster.getBoosterFromStorage().mythic).toEqual([]);
+      expect(Booster.haveBoosterEquiped('MB1')).toBeFalsy();
+    });
+  });
+
+  describe("getSandalwoodDosesRemaining -- a missing count is not a count (issue #1874)", function() {
+    const store = (mythic: object[]) =>
+      sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_boosterStatus", JSON.stringify({ normal: [], mythic }));
+
+    it("returns null when the entry carries no usages_remaining", function() {
+      store([{ item: { identifier: 'MB1' }, price_buy: 900 }]);
+
+      expect(Booster.getSandalwoodDosesRemaining()).toBeNull();
+      expect(Booster.hasUntrustworthySandalwoodEntry()).toBeTruthy();
+    });
+
+    it("returns 0 for a spent perfume, which is a real count", function() {
+      store([{ item: { identifier: 'MB1' }, usages_remaining: 0 }]);
+
+      expect(Booster.getSandalwoodDosesRemaining()).toBe(0);
+      expect(Booster.hasUntrustworthySandalwoodEntry()).toBeFalsy();
+    });
+
+    it("reports nothing untrustworthy when Sandalwood is not tracked at all", function() {
+      store([]);
+
+      expect(Booster.getSandalwoodDosesRemaining()).toBeNull();
+      expect(Booster.hasUntrustworthySandalwoodEntry()).toBeFalsy();
+    });
+  });
+
   describe("needSandalWoodEquipped", function() {
     it("returns false when no settings active", function() {
       expect(Booster.needSandalWoodEquipped(1)).toBeFalsy();

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -1,7 +1,7 @@
 import { ConfigHelper } from "../Helper/ConfigHelper";
 import { HeroHelper } from "../Helper/HeroHelper";
 import { getHHVars } from "../Helper/HHHelper";
-import { getStoredJSON, getStoredValue, setStoredValue } from "../Helper/StorageHelper";
+import { deleteStoredValue, getStoredJSON, getStoredValue, setStoredValue } from "../Helper/StorageHelper";
 import { randomInterval } from "../Helper/TimeHelper";
 import { checkTimer, setTimer } from "../Helper/TimerHelper";
 import { gotoPage, safeReload } from "../Service/PageNavigationService";
@@ -302,11 +302,36 @@ export class Booster {
         }
     }
 
+    /**
+     * An equipped booster carries the id of its equip row. The market page
+     * serves a second family of elements with the very same `slot ... mythic`
+     * classes under `#player-inventory-booster` -- the ones you can buy or
+     * equip -- and those payloads have `price_buy` and no `usages_remaining`.
+     *
+     * Measured on the live market page: the three equipped slots all carry
+     * `id_member_booster_equipped`, `lifetime`, `expiration` and
+     * `usages_remaining`; the five inventory entries carry `price_buy` and
+     * none of those. An inventory payload that reaches boosterStatus makes
+     * haveBoosterEquiped() answer true for a booster that is not on, and the
+     * dose count is then missing rather than zero -- so the depletion check
+     * (`<= 0`) never fires and Sandalwood is never re-equipped (issue #1874).
+     */
+    static isEquippedBoosterPayload(data: any): boolean {
+        return !!data && data.id_member_booster_equipped !== undefined && data.id_member_booster_equipped !== null;
+    }
+
     static collectBoostersFromMarket() {
-        const activeSlots = $('#equiped .booster .slot:not(.empty):not(.mythic)').map((i, el)=> $(el).data('d')).toArray()
-        const activeMythicSlots = $('#equiped .booster .slot:not(.empty).mythic').map((i, el)=> $(el).data('d')).toArray()
+        const rawSlots = $('#equiped .booster .slot:not(.empty):not(.mythic)').map((i, el)=> $(el).data('d')).toArray()
+        const rawMythicSlots = $('#equiped .booster .slot:not(.empty).mythic').map((i, el)=> $(el).data('d')).toArray()
+
+        const activeSlots = rawSlots.filter(Booster.isEquippedBoosterPayload);
+        const activeMythicSlots = rawMythicSlots.filter(Booster.isEquippedBoosterPayload);
+        const dropped = (rawSlots.length - activeSlots.length) + (rawMythicSlots.length - activeMythicSlots.length);
 
         logHHAuto(`collectBoostersFromMarket: found ${activeSlots.length} normal boosters, ${activeMythicSlots.length} mythic boosters equipped`);
+        if (dropped > 0) {
+            logHHAuto(`collectBoostersFromMarket: ignored ${dropped} slot payload(s) that are not equipped boosters`);
+        }
 
         const boosterStatus = {
             normal: activeSlots.map((data) => ({...data, endAt: getHHVars('server_now_ts') + data.expiration})),
@@ -966,16 +991,26 @@ export class Booster {
 
         logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
 
-        // Proactive depletion check: if Sandalwood is equipped but has 0 doses remaining,
-        // remove it from boosterStatus so ownedSandalwoodAndNotEquiped() triggers re-equip.
+        // Drop the Sandalwood entry when it is spent, and equally when it cannot
+        // say how much is left: ownedSandalwoodAndNotEquiped() then reports it as
+        // not equipped and the equip path runs. An entry without a dose count is
+        // what an inventory payload looks like once it has been scraped into
+        // boosterStatus, and leaving it there is what kept the perfume off for
+        // the rest of a session (issue #1874).
         if (needForEvent || needForMythic || needForLoveRaid) {
             const dosesRemaining = Booster.getSandalwoodDosesRemaining();
-            logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}`);
-            if (dosesRemaining !== null && dosesRemaining <= 0) {
-                logHHAuto('needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
+            const untrustworthy = Booster.hasUntrustworthySandalwoodEntry();
+            logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}, untrustworthy=${untrustworthy}`);
+            if (untrustworthy || (dosesRemaining !== null && dosesRemaining <= 0)) {
+                logHHAuto(untrustworthy
+                    ? 'needSandalWoodEquipped: Sandalwood entry carries no dose count, dropping it to trigger re-equip'
+                    : 'needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
                 const boosterStatus = Booster.getBoosterFromStorage();
                 boosterStatus.mythic = boosterStatus.mythic.filter(b => b.item?.identifier !== 'MB1');
                 setStoredValue(HHStoredVarPrefixKey+TK.boosterStatus, JSON.stringify(boosterStatus));
+                // The stored status no longer matches the market: let the next
+                // autoEquipBoosters pass refresh it instead of trusting this one.
+                deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
             }
         }
 
@@ -1254,14 +1289,34 @@ export class Booster {
     }
 
     /**
-     * Returns the number of remaining Sandalwood doses from boosterStatus.
-     * Returns null if Sandalwood is not currently equipped.
+     * Remaining Sandalwood doses, or null when there is no number to give:
+     * Sandalwood is not tracked as equipped, or its entry carries no usable
+     * count.
+     *
+     * The raw field used to be returned as it stood. An entry without one then
+     * yielded `undefined`, and the caller's `dosesRemaining !== null &&
+     * dosesRemaining <= 0` let it through the first test and failed the second
+     * -- a missing count read as "plenty left" (issue #1874). A count is a
+     * number here or it is null, and null means "ask the market", not "fine".
      */
     static getSandalwoodDosesRemaining(): number | null {
         const boosterStatus = Booster.getBoosterFromStorage();
         const sandalwood = boosterStatus.mythic.find(b => b.item?.identifier === 'MB1');
         if (!sandalwood) return null;
-        return sandalwood.usages_remaining;
+        const doses = Number(sandalwood.usages_remaining);
+        return Number.isFinite(doses) ? doses : null;
+    }
+
+    /**
+     * True when Sandalwood is tracked as equipped but its entry cannot say how
+     * many doses are left. The entry is then not trustworthy -- it is what an
+     * inventory payload scraped into boosterStatus looks like -- and the
+     * caller drops it so the equip path runs again (issue #1874).
+     */
+    static hasUntrustworthySandalwoodEntry(): boolean {
+        const boosterStatus = Booster.getBoosterFromStorage();
+        const sandalwood = boosterStatus.mythic.find(b => b.item?.identifier === 'MB1');
+        return !!sandalwood && Booster.getSandalwoodDosesRemaining() === null;
     }
 
 }

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -316,7 +316,7 @@ export class Booster {
      * dose count is then missing rather than zero -- so the depletion check
      * (`<= 0`) never fires and Sandalwood is never re-equipped (issue #1874).
      */
-    static isEquippedBoosterPayload(data: any): boolean {
+    static isEquippedBoosterPayload(data: { id_member_booster_equipped?: unknown } | null | undefined): boolean {
         return !!data && data.id_member_booster_equipped !== undefined && data.id_member_booster_equipped !== null;
     }
 


### PR DESCRIPTION
Refs #1874. This is what the two logs on that issue actually show; 8.12.2 fixed a different path, whose failure counter is 0 in both of them.

## Measured

On the live market page, the classes `slot ... mythic` sit on two families of elements:

```
#equiped .booster .slot:not(.empty).mythic   ->  MB1, MB2, MB5
  keys: expiration, id_item, id_member, id_member_booster_equipped,
        item, lifetime, price_sell, usages_remaining

#player-inventory-booster .slot ... mythic   ->  MB1, MB2, MB5, MB7, MB9
  keys: id_item, id_member, item, price_buy, price_sell
```

A worn booster carries `id_member_booster_equipped` and a dose count; an owned-but-not-worn one carries `price_buy` and no count at all. `item.default_usages` holds the full count in both (MB1 11, MB2 100, MB5 100), and the game's own renderer falls back to it: `t.usages_remaining && t.usages_remaining > 0 ? t.usages_remaining : t.item.default_usages`.

In the reported log, `boosterStatus.mythic` ends with an MB1 entry whose key set is exactly the inventory one. It was written by `collectBoostersFromMarket` at 8:19:13.508, one and a half seconds after an equip that reported 11 doses at 8:19:12.027. The other account's log has no scrape after its equip and ends with the correct 11.

From there `haveBoosterEquiped('MB1')` answered true, and `getSandalwoodDosesRemaining()` returned the absent field as `undefined`: `dosesRemaining !== null` passes, `<= 0` fails, so the depletion check ran on every pass and never fired. The perfume ran out and nothing replaced it.

## Changes

- `collectBoostersFromMarket` keeps only payloads carrying `id_member_booster_equipped`, normal and mythic alike, and logs what it dropped.
- `getSandalwoodDosesRemaining` returns a number or null, never the raw field.
- `needSandalWoodEquipped` drops an entry that cannot say how many doses are left and clears `boosterStatusLastUpdate`, so an account already carrying one recovers on the next pass rather than needing a reinstall.

The same trap is already documented for armor (`id_member_armor_equipped` vs `id_member_armor`, which discarded all six worn pieces in August). `docs-internal/data-sources-inventory.md` now carries the booster measurement next to it.

## Tests

Five new cases in `spec/Module/Booster.spec.ts` built from the payload shapes measured on the live page. Two of them fail when the filter and the accessor are reverted to their old behaviour.

All gates green: typecheck, lint:ci, 1504 tests, deps:circular:check, check:gm-grants, check:docs, check:headers, check:player-data, build.

## Not covered

Why the `#equiped` slot carried an inventory payload at that instant is not established — a booster cannot be unequipped, so the state cannot be reproduced on demand. It does not change the fix: the two payload shapes are distinguishable, and the script has to tell them apart whatever puts one in front of it.

Separately, HHauto observes the troll battle response 1 time in 146 fights across the two logs (`notifyBattleResponseProcessed`: 0 of 61, 1 of 85) because a single fight is a page load of `/troll-battle.html`. That costs the live dose tracking, but doses are only spent when shards drop — measured against the running game — so it drifts by a handful per session and the market scrape corrects it. Left for its own ticket.