### PR TITLE
fix(login-script): start at document-end and say why it failed

### DIFF
--- a/bonus-scripts/HHAuto-Login.user.js
+++ b/bonus-scripts/HHAuto-Login.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HHAuto Login
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      1.4
+// @version      1.5
 // @description  HHAuto Login
 // @author       Zary, OldRon1977
 // @match        https://connect.chibipass.com/*
@@ -238,9 +238,20 @@ function init() {
     }
 }
 
-// "load" is the one start point. At the default @run-at document-end the
-// DOMContentLoaded event has already been dispatched, so a listener for it
-// never fires; at document-start both would fire and init would run twice,
-// submitting the form a second time. The ChibiPass form is server-rendered,
-// not an SPA, so there is nothing later to wait for.
-window.addEventListener("load", init);
+// Do not wait for "load". These pages keep fetching advertising frames for as
+// long as they are open, and anything that waits for the document to settle
+// waits on that too: a reload extension set to ten minutes never fired on this
+// game while the same extension set to one second did. Whether the load event
+// itself is held back was not measured -- but the script has no reason to
+// depend on it either way.
+//
+// At the default @run-at document-end readyState is already "interactive"
+// (measured in all three frames), so init() simply runs. Waiting for the form
+// is waitForElement's job, not the load event's. The DOMContentLoaded branch
+// only matters if a manager injects at document-start; loginSubmitted keeps
+// that to one submit.
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+} else {
+    init();
+}

--- a/bonus-scripts/HHAuto-Login.user.js
+++ b/bonus-scripts/HHAuto-Login.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HHAuto Login
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      1.3
+// @version      1.4
 // @description  HHAuto Login
 // @author       Zary, OldRon1977
 // @match        https://connect.chibipass.com/*
@@ -86,6 +86,20 @@
 const userEmail = "YOUR_EMAIL";
 const userPass = "YOUR_PASSWORD";
 
+// How long to wait for the ChibiPass form. The old budget was 10 seconds,
+// which is generous for a hand-made reload and too short for one that happens
+// while the connection is still coming back: the iframe is then empty, the
+// wait expires, and init() does not run again until the next page load.
+const FORM_WAIT_MS = 60000;
+
+// Every message carries this so the browser console can be filtered down to
+// this script. Without it a failure is invisible between a few hundred lines
+// from the other userscripts on the page.
+const TAG = "[HHAuto-Login]";
+
+// One submit per document, whatever calls login().
+let loginSubmitted = false;
+
 function waitForElement(selector, timeout = 10000) {
     return new Promise((resolve, reject) => {
         const interval = 200;
@@ -107,12 +121,31 @@ function waitForElement(selector, timeout = 10000) {
     });
 }
 
+// What the form looks like right now. Logged when a selector is missing, so
+// the next failure says whether the form was absent altogether or whether
+// ChibiPass opened on a different panel than the password one this script
+// fills. The panels measured on 2026-09-03 were: authenticate (the one used
+// here), passwordless-authenticate, register, passwordless-register,
+// forgotten-password, reset-password and external-connect.
+function describeForm() {
+    const active = document.querySelector(".form-container.active");
+    return {
+        activePanel: active ? active.id : null,
+        panels: [...document.querySelectorAll(".form-container")].map(e => e.id),
+        inputs: [...document.querySelectorAll("input")].map(e => e.id).filter(Boolean),
+        readyState: document.readyState,
+    };
+}
+
 // Runs inside the ChibiPass form iframe (see SCOPE above).
 async function login() {
+    if (loginSubmitted) return;
+    loginSubmitted = true;
+
     try {
-        const email = await waitForElement("#auth-email");
-        const pass = await waitForElement("#auth-password");
-        const btn = await waitForElement("#submit-authenticate");
+        const email = await waitForElement("#auth-email", FORM_WAIT_MS);
+        const pass = await waitForElement("#auth-password", FORM_WAIT_MS);
+        const btn = await waitForElement("#submit-authenticate", FORM_WAIT_MS);
 
         email.value = userEmail;
         pass.value = userPass;
@@ -135,9 +168,10 @@ async function login() {
         if (btn.disabled) btn.disabled = false;
         btn.click();
 
-        console.log("Login sent");
+        console.log(TAG, "login sent");
     } catch (err) {
-        console.error("Login error:", err);
+        loginSubmitted = false;
+        console.error(TAG, "login failed:", err, describeForm());
     }
 }
 
@@ -160,7 +194,7 @@ function enterGame() {
             // has appeared, so skip it and keep looking.
             if (btn && !btn.closest("a[rel='phoenix_member_login']")) {
                 btn.click();
-                console.log("Entered the game.");
+                console.log(TAG, "entered the game");
                 return true;
             }
         } catch (e) {
@@ -186,9 +220,14 @@ function isGamePage() {
 }
 
 function init() {
+    // Logged before anything can bail out. Silence used to mean either "the
+    // script did not run in this frame" or "it ran and gave up", and the two
+    // need different fixes.
+    console.log(TAG, isLoginPage() ? "login form" : "game page", location.href);
+
     if (!userEmail || !userPass
         || userEmail === "YOUR_EMAIL" || userPass === "YOUR_PASSWORD") {
-        console.warn("Credentials not defined");
+        console.warn(TAG, "credentials not defined");
         return;
     }
 

--- a/bonus-scripts/README.md
+++ b/bonus-scripts/README.md
@@ -23,7 +23,13 @@ purpose — remove the domains you do not play, and do not widen the list.
 1. Install the script, fill in `userEmail` / `userPass`.
 2. Log out of the game and open the game domain root (e.g. `https://www.hentaiheroes.com/`).
 3. The ChibiPass form is served into an iframe of that same page, not as a
-   separate redirect. It must be filled and submitted automatically ("Login
-   sent" in the console of the `connect.chibipass.com` frame).
+   separate redirect. It must be filled and submitted automatically.
+
+Every message the script prints starts with `[HHAuto-Login]`, so filter the
+console on that -- the game pages carry a few hundred lines from other
+userscripts. Expect one `login form`/`game page` line per frame the script
+runs in, then `login sent`. A failure prints `login failed:` together with the
+panel and input ids the form actually had, which says whether the form was
+missing or whether ChibiPass opened on a panel other than the password one.
 4. Back on the landing page, the "enter game" button must be clicked automatically ("Entered the game." in the console).
 5. Verify the script does **not** run inside the game (no console entries on `/home.html`).


### PR DESCRIPTION
Tested overnight on the running game by the maintainer: the login survived the
night. Measured against the live pages beforehand, logged out, with the
ChibiPass auth request intercepted before it left the browser.

## The symptom

A hand-made F5 logged in. A reload after being thrown off the game -- a modem
restart, say -- did not, even though an extension reloads the page every ten
minutes.

## The cause

These pages keep fetching advertising frames for as long as they are open, so
anything that waits for the document to settle waits on that too. Reported
from the running game: the reload extension set to ten minutes never fired,
the same extension set to one second did.

The script waited for the same thing:

```js
window.addEventListener("load", init);
```

It had no reason to. At the default `@run-at document-end` `readyState` is
already `"interactive"` -- measured in all three frames -- so `init()` simply
runs there, and waiting for the form was already `waitForElement`'s job.

Whether the load event on these pages is actually held back indefinitely was
not measured, only that something which waits for the page to settle does not
fire. Either way the dependency is gone.

This removes one link in the chain, not all of them: a userscript still needs
a document load to run at all. If nothing reloads the page after a session is
lost, nothing starts.

## The rest of the change

**The wait for the form goes from 10s to 60s.** Ten seconds is generous for a
reload made by hand and short for one that happens while the connection is
still coming back: the iframe is empty, the wait expires, and `init()` runs
once per document.

**Failures now say what the form actually was.** `login failed:` carries the
active panel id, every panel id, the input ids and the readyState. ChibiPass
serves seven panels into that iframe -- authenticate, passwordless-
authenticate, register, passwordless-register, forgotten-password,
reset-password, external-connect -- and this script fills the first. If a kick
opens a different one, the log says so instead of only naming the missing
selector.

**Every message is prefixed `[HHAuto-Login]`,** and `init()` logs its frame
before anything can bail out. Silence used to mean either "never ran in this
frame" or "ran and gave up", which need different fixes, and neither was
distinguishable between the few hundred lines the other userscripts print on
these pages.

**A `loginSubmitted` guard** makes it one submit per document however often
`init` runs, and is cleared on failure so a later attempt stays possible.

## Verification

All three frames log their start line at readyState `"interactive"` with the
load event not yet fired, and the ChibiPass frame sends exactly one POST to
`/authentication/authenticate` -- also when `init` is forced to run twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
