### PR TITLE
fix(gear): Upgrade Gear works through every worn mythic, without needing a team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.12.4 - Upgrade Gear works through every worn mythic, and scrolls for material
+
+Two things ended an "Upgrade Gear" run after a single item.
+
+The material list on the upgrade page is paged: the game renders a first batch
+and loads the next one only in answer to a scroll -- it never fills itself.
+Auto Select picks from what is rendered, so once the first batch no longer
+covered a level, the Level-up button stayed dark and the run read that as "the
+material is spent". It showed up around level 19 to 20, where the requirement
+is largest. The run now scrolls the list to its end before it believes a dark
+button, and asks Auto Select again with the full stock in view.
+
+The second one hit the successful case. At the cap the game navigates off the
+upgrade page by itself, so the code that moved the queue on to the next item
+never ran -- the queue sat in storage until it aged out. The remaining queue is
+now written before the level that reaches the cap, and the market page opens
+whatever is left, so a run walks through every worn mythic below level 20 in
+one go.
+
+Material that genuinely runs out still ends the whole run, and one item is
+taken to level 20 before the next one starts.
+
 ### v8.12.3 - The market scrape no longer files a shop entry as an equipped booster
 
 Fixes Sandalwood never being replaced once it runs out (issue #1874, reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.12.5 - Upgrade Gear no longer waits for a team, and stops scrolling sooner
+
+The button refused to do anything until a team theme was known, and told you to
+open your team page first. That was the wrong condition. What it upgrades is
+what you are wearing, and the game knows that without a team; the theme only
+decides which of your worn mythics is fed first. Without one the list is
+ordered by class match and slot, every worn mythic below level 20 is still
+worked through, and the preview says the order is the coarser one. The two
+equip buttons keep the requirement -- those pick items, and picking on a
+guessed theme puts the wrong item on.
+
+The other half is the waiting. Scrolling the material list stopped when the
+game stopped adding to it, which meant every run scrolled to the very end of
+the list even though the requirement was usually covered a few batches in --
+and every item in the queue paid it again on its own page. Auto Select is now
+asked again while the list grows, and the scrolling ends the first time the
+game lights up Level-up. A level that the stock genuinely cannot cover still
+walks the whole list, because that is the only way to know it cannot.
+
 ### v8.12.4 - Upgrade Gear works through every worn mythic, and scrolls for material
 
 Two things ended an "Upgrade Gear" run after a single item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,31 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
-### v8.12.5 - Upgrade Gear no longer waits for a team, and stops scrolling sooner
+### v8.12.4 - Upgrade Gear works through every worn mythic, without needing a team
 
-The button refused to do anything until a team theme was known, and told you to
-open your team page first. That was the wrong condition. What it upgrades is
-what you are wearing, and the game knows that without a team; the theme only
-decides which of your worn mythics is fed first. Without one the list is
-ordered by class match and slot, every worn mythic below level 20 is still
-worked through, and the preview says the order is the coarser one. The two
-equip buttons keep the requirement -- those pick items, and picking on a
-guessed theme puts the wrong item on.
+Three things stood between the button and the items you wear.
 
-The other half is the waiting. Scrolling the material list stopped when the
-game stopped adding to it, which meant every run scrolled to the very end of
-the list even though the requirement was usually covered a few batches in --
-and every item in the queue paid it again on its own page. Auto Select is now
-asked again while the list grows, and the scrolling ends the first time the
-game lights up Level-up. A level that the stock genuinely cannot cover still
-walks the whole list, because that is the only way to know it cannot.
-
-### v8.12.4 - Upgrade Gear works through every worn mythic, and scrolls for material
-
-Two things ended an "Upgrade Gear" run after a single item.
+It refused to run until a team theme was known and sent you to the team page
+first. That was the wrong condition. What it upgrades is what you are wearing,
+and the game knows that without a team; the theme only decides which of your
+worn mythics is fed first. Without one the order is by class match and slot,
+every worn mythic below level 20 is still worked through, and the preview says
+the order is the coarser one. The two equip buttons keep the requirement --
+those pick items, and picking on a guessed theme puts the wrong item on.
 
 The material list on the upgrade page is paged: the game renders a first batch
 and loads the next one only in answer to a scroll -- it never fills itself.
 Auto Select picks from what is rendered, so once the first batch no longer
 covered a level, the Level-up button stayed dark and the run read that as "the
 material is spent". It showed up around level 19 to 20, where the requirement
-is largest. The run now scrolls the list to its end before it believes a dark
-button, and asks Auto Select again with the full stock in view.
+is largest. A dark button is now only believed after the list has been
+scrolled, and the scrolling stops the first time the game lights up Level-up
+rather than at the end of the list -- the requirement is usually covered a few
+batches in, and walking the rest bought nothing while you watched it scroll. A
+level the stock genuinely cannot cover still walks the whole list, because
+that is the only way to know it cannot.
 
-The second one hit the successful case. At the cap the game navigates off the
+The third one hit the successful case. At the cap the game navigates off the
 upgrade page by itself, so the code that moved the queue on to the next item
 never ran -- the queue sat in storage until it aged out. The remaining queue is
 now written before the level that reaches the cap, and the market page opens

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.5
+// @version      8.12.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.3
+// @version      8.12.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -20643,6 +20643,17 @@ const MAX_INVENTORY_PAGES = 120;
 /** How long a queue may sit untouched before the market page forgets it.
  *  Long enough to survive the navigation the Start button triggers. */
 const STALE_QUEUE_MS = 90000;
+/** How often the market list may be scrolled before accepting that nothing
+ *  more arrives. The game pages it in batches (measured: 100 slots on
+ *  arrival, 299 after scrolling to the end) and the test account held 1614
+ *  armors, so this has to allow a lot of passes; it bounds a changed page,
+ *  not a normal inventory. */
+const MAX_MATERIAL_SCROLLS = 60;
+/** How often the market page may re-open the same head before giving up on
+ *  it. Two chances, because the first may be the hand-off after the game's
+ *  own redirect and the second a genuine retry; a third means the page is
+ *  not opening at all. */
+const MAX_QUEUE_HEAD_TRIES = 3;
 const SLOT_NAMES = {
     1: 'Head', 2: 'Body', 3: 'Legs', 4: 'Flag', 5: 'Pet', 6: 'Weapon',
 };
@@ -20663,7 +20674,7 @@ class EquipmentGear {
     static moduleGearActions() {
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDShop"))
             return;
-        EquipmentGear.dropStaleUpgradeQueue();
+        EquipmentGear.resumeUpgradeQueue();
         EquipmentGear.watchTabSwitch();
         // The player's own inventory has its own tab strip
         // (.my-hero-switch-tab: booster / armor / player-stats), separate
@@ -20750,27 +20761,60 @@ class EquipmentGear {
         });
     }
     /**
-     * Forget an upgrade queue that is no longer being worked on.
+     * Carry an upgrade run on from the market page, or forget it.
      *
-     * At the cap the game redirects off the upgrade page by itself, so the
-     * loop never reaches its own clean-up and the queue would sit in storage
-     * until the player happened to open an upgrade page again. Being back on
-     * the market with an old queue means the run is over one way or another.
-     * The age check is what keeps this from eating the queue the Start button
-     * just wrote, one navigation earlier.
+     * The market is where a run both starts and lands: at the cap the game
+     * navigates off the upgrade page by itself, so the hand-off to the next
+     * item cannot happen there -- the upgrade page writes the remaining queue
+     * before it triggers that redirect, and this opens whatever it left. The
+     * Start button leaves the same state behind, so both cases are one code
+     * path.
+     *
+     * An old queue is dropped instead: being back here with one means the run
+     * is over one way or another. The age check is what keeps that from
+     * eating the queue the Start button just wrote, one navigation earlier.
      */
-    static dropStaleUpgradeQueue() {
+    static resumeUpgradeQueue() {
         var _a;
+        if (EquipmentGear.resumeNavigating)
+            return;
         const queue = getStoredJSON(HHStoredVarPrefixKey + TK.gearUpgradeQueue, []);
         if (!Array.isArray(queue) || queue.length === 0)
             return;
         const startedAt = Number((_a = queue[0]) === null || _a === void 0 ? void 0 : _a.startedAt) || 0;
-        if (Date.now() - startedAt < STALE_QUEUE_MS)
+        if (Date.now() - startedAt >= STALE_QUEUE_MS) {
+            setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
+            EquipmentGear.releaseAutoLoop();
+            logHHAuto(`Gear: dropping a stale upgrade queue (${queue.length} item(s) left);`
+                + ' the run is no longer on the upgrade page.');
             return;
-        setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
-        EquipmentGear.releaseAutoLoop();
-        logHHAuto(`Gear: dropping a stale upgrade queue (${queue.length} item(s) left);`
-            + ' the run is no longer on the upgrade page.');
+        }
+        const head = queue[0];
+        const tries = (Number(head.tries) || 0) + 1;
+        if (tries > MAX_QUEUE_HEAD_TRIES) {
+            // The upgrade page for this item does not open -- it bounces
+            // straight back here, so nothing was spent on it. Skipping it is
+            // the only way the rest of the queue gets its turn.
+            const rest = queue.slice(1);
+            logHHAuto(`Gear: ${head.name} (slot ${head.slot}) did not open after`
+                + ` ${MAX_QUEUE_HEAD_TRIES} attempt(s); skipping it,`
+                + ` ${rest.length} item(s) left.`);
+            if (rest.length === 0) {
+                setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
+                EquipmentGear.releaseAutoLoop();
+                logHHAuto('Gear: upgrade run finished -- nothing left to open.');
+                return;
+            }
+            setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, JSON.stringify(rest.map(r => (Object.assign(Object.assign({}, r), { startedAt: Date.now(), tries: 0 })))));
+            EquipmentGear.resumeNavigating = true;
+            EquipmentGear.gotoUpgradePage(rest[0].id);
+            return;
+        }
+        setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, JSON.stringify([Object.assign(Object.assign({}, head), { tries }), ...queue.slice(1)]));
+        logHHAuto(`Gear: upgrade run continues with ${head.name} (slot ${head.slot});`
+            + ` ${queue.length} item(s) left.`);
+        EquipmentGear.resumeNavigating = true;
+        EquipmentGear.gotoUpgradePage(head.id);
     }
     /** Re-run the injection after a tab switch. The market swaps tabs without
      *  a page load, and it opens on Boosters -- so a one-shot injection from
@@ -21317,11 +21361,13 @@ class EquipmentGear {
             </table>
             <p><b>Material:</b> ${stock.legendary.toLocaleString()} legendary and
                ${stock.epic.toLocaleString()} epic items. Mythics are never consumed.</p>
-            <p style="color:#aaa;font-size:11px;">The upgrade page shows each item's exact
+            <p style="color:#aaa;font-size:11px;">One item is taken to level ${(/* inlined export .MYTHIC_MAX_LEVEL */20)}
+               before the next one starts. The upgrade page states each item's exact
                requirement, and the run stops by itself once the material is spent.</p>
             <p id="HHGearStatus" style="color:#ffb827;"></p>
             <label class="myButton" id="HHGearUpgradeStart" style="font-size:14px;width:100%;text-align:center;">
-                Start with ${esc(targets[0].name)} (slot ${targets[0].slot})</label>
+                Level all ${targets.length} item(s), starting with ${esc(targets[0].name)}
+                (slot ${targets[0].slot})</label>
         </div>`);
         $('#HHGearUpgradeStart').on('click', function () {
             $(this).attr('disabled', 'disabled').css('opacity', '0.5');
@@ -21360,14 +21406,86 @@ class EquipmentGear {
     static isUpgradePage() {
         return window.location.pathname.indexOf(UPGRADE_PATH) !== -1;
     }
+    /** The game's own verdict on whether the picked material covers the next
+     *  level. Read fresh every time: Auto Select and a scroll both change it. */
+    static levelUpEnabled() {
+        const button = document.getElementById('level-up');
+        return button !== null && !button.disabled;
+    }
+    /** Material pieces the page has rendered so far. This is the number Auto
+     *  Select works from, not the number the account owns. */
+    static countMaterialSlots() {
+        return document.querySelectorAll('.slot[data-d]').length;
+    }
+    /**
+     * The elements that actually scroll the material list.
+     *
+     * Anchored on the list and walked upwards rather than named by a fixed
+     * selector: whether the overflow sits on `.items-container` itself or on
+     * an ancestor is the page's business, and the window is included because
+     * a list that fills the document scrolls with it.
+     */
+    static materialScrollTargets() {
+        const out = [];
+        let el = document.querySelector('.items-container');
+        while (el !== null) {
+            if (el.scrollHeight > el.clientHeight + 20) {
+                const overflow = getComputedStyle(el).overflowY;
+                if (overflow === 'auto' || overflow === 'scroll')
+                    out.push(el);
+            }
+            el = el.parentElement;
+        }
+        return out;
+    }
+    /**
+     * Scroll the material list until the game stops adding to it.
+     *
+     * The list is paged and the game loads the next batch only in answer to a
+     * scroll -- it never fills itself (confirmed on the live page; the counts
+     * measured earlier were 100 slots on arrival and 299 after scrolling to
+     * the end). Auto Select chooses among the rendered pieces, so everything
+     * beyond the first batch is invisible to it until this has run.
+     *
+     * Two idle passes before stopping, not one: a batch that is still in
+     * flight when the first pass is counted would otherwise end the loading
+     * early, and stopping early is exactly the failure this exists to remove.
+     */
+    static loadAllMaterial() {
+        return EquipmentGear_awaiter(this, void 0, void 0, function* () {
+            var _a, _b;
+            let count = EquipmentGear.countMaterialSlots();
+            let idle = 0;
+            for (let pass = 0; pass < MAX_MATERIAL_SCROLLS; pass++) {
+                for (const target of EquipmentGear.materialScrollTargets()) {
+                    target.scrollTop = target.scrollHeight;
+                }
+                window.scrollTo(0, (_b = (_a = document.scrollingElement) === null || _a === void 0 ? void 0 : _a.scrollHeight) !== null && _b !== void 0 ? _b : 0);
+                yield new Promise(r => setTimeout(r, randomInterval(600, 900)));
+                const now = EquipmentGear.countMaterialSlots();
+                if (now === count) {
+                    if (++idle >= 2)
+                        return count;
+                }
+                else {
+                    idle = 0;
+                    count = now;
+                }
+            }
+            logHHAuto(`Gear: stopped scrolling the material list at ${count} piece(s) after`
+                + ` ${MAX_MATERIAL_SCROLLS} passes; it was still growing.`);
+            return count;
+        });
+    }
     /**
      * Work the queue on the upgrade page: Auto Select, then Level-up, until
      * the item is capped or the material runs out.
      *
      * Auto Select is the game's own material picker, and the Level-up button
-     * only lights up once it has covered the requirement -- so a button that
-     * stays disabled is the game telling us the stock is spent. Nothing here
-     * counts material or reimplements the cost curve.
+     * only lights up once it has covered the requirement. Nothing here counts
+     * material or reimplements the cost curve -- but a dark button is only
+     * believed once the whole material list has been scrolled into the page,
+     * because Auto Select can pick only from what is rendered.
      *
      * Does nothing at all while the queue is empty, which is the state
      * unless the player pressed the button.
@@ -21409,14 +21527,50 @@ class EquipmentGear {
                 // value is the only reliable level here. Over-counting a failed
                 // call only makes this stop early, which is the safe direction.
                 const startLevel = Number((_g = unsafeWindow.item_to_upgrade) === null || _g === void 0 ? void 0 : _g.level) || 0;
+                const rest = queue.slice(1);
+                /** Hand the queue on before the level that reaches the cap, not
+                 *  after: the game navigates off this page the moment an item is
+                 *  capped, so nothing below that click is guaranteed to run. The
+                 *  market page finds the next item waiting and opens it. When this
+                 *  was the last item there is no next page to clean up either, so
+                 *  the clean-up happens here too. */
+                let handedOver = false;
+                const handOver = (lastMsg) => {
+                    if (handedOver)
+                        return;
+                    handedOver = true;
+                    if (rest.length === 0) {
+                        finish(lastMsg);
+                        return;
+                    }
+                    setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, JSON.stringify(rest.map(r => (Object.assign(Object.assign({}, r), { startedAt: Date.now(), tries: 0 })))));
+                    logHHAuto(`Gear: moving on to ${rest[0].name} (slot ${rest[0].slot}).`);
+                };
                 let performed = 0;
                 for (;;) {
                     $('#auto-select').trigger('click');
                     yield new Promise(r => setTimeout(r, randomInterval(700, 1200)));
-                    const enabled = $('#level-up').length > 0
-                        && !document.getElementById('level-up').disabled;
+                    if (!EquipmentGear.levelUpEnabled()) {
+                        // A disabled button is not proof that the material is
+                        // spent. The game renders the material list in batches and
+                        // loads the next one only while it is scrolled, and Auto
+                        // Select picks from what is rendered -- so an unscrolled
+                        // list reads as "not enough material" for a level the
+                        // stock covers. It shows up around 19 -> 20, where the
+                        // requirement is largest and the first batch no longer
+                        // carries it.
+                        const before = EquipmentGear.countMaterialSlots();
+                        const after = yield EquipmentGear.loadAllMaterial();
+                        if (after > before) {
+                            logHHAuto(`Gear: material list grew from ${before} to ${after} piece(s)`
+                                + ' after scrolling; asking Auto Select again.');
+                            $('#auto-select').trigger('click');
+                            yield new Promise(r => setTimeout(r, randomInterval(700, 1200)));
+                        }
+                    }
                     const verdict = decideNextLevelUp({
-                        currentLevel: startLevel + performed, levelUpEnabled: enabled,
+                        currentLevel: startLevel + performed,
+                        levelUpEnabled: EquipmentGear.levelUpEnabled(),
                     });
                     if (!verdict.go) {
                         logHHAuto(`Gear: stopping on ${head.name} after ${performed} level(s) -- ${verdict.reason}.`);
@@ -21424,7 +21578,12 @@ class EquipmentGear {
                             finish(verdict.reason);
                             return;
                         }
+                        handOver('every queued item is done.');
                         break;
+                    }
+                    if (startLevel + performed + 1 >= (/* inlined export .MYTHIC_MAX_LEVEL */20)) {
+                        handOver(`${head.name} reaches level ${(/* inlined export .MYTHIC_MAX_LEVEL */20)}`
+                            + ' with the level-up going out now.');
                     }
                     $('#level-up').trigger('click');
                     performed++;
@@ -21432,13 +21591,8 @@ class EquipmentGear {
                     logHHAuto(`Gear: ${head.name} is now level ${startLevel + performed}`
                         + ` (${performed} level(s) this run).`);
                 }
-                const rest = queue.slice(1);
-                if (rest.length === 0) {
-                    finish('every queued item is done.');
+                if (rest.length === 0)
                     return;
-                }
-                setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, JSON.stringify(rest.map(r => (Object.assign(Object.assign({}, r), { startedAt: Date.now() })))));
-                logHHAuto(`Gear: moving on to ${rest[0].name} (slot ${rest[0].slot}).`);
                 EquipmentGear.gotoUpgradePage(rest[0].id);
             }
             catch (err) {
@@ -21515,6 +21669,10 @@ class EquipmentGear {
 }
 /** Guards against a second injection when the page handler runs again. */
 EquipmentGear.running = false;
+/** One navigation per page load. The market handler runs on every autoloop
+ *  tick, and `location.href` does not take effect before the next one --
+ *  without this the retry budget would be spent waiting for the browser. */
+EquipmentGear.resumeNavigating = false;
 EquipmentGear.tabWatcherBound = false;
 EquipmentGear.upgradeObserver = null;
 EquipmentGear.upgradeMarksLogged = false;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.12.4
+// @version      8.12.5
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -20202,6 +20202,14 @@ function resonancePoints(item, playerClass, theme, projected) {
  * Tier 5 also holds every legendary and epic. Those carry no resonance at
  * all: of the 12 legendary slots in the league, none had a class or theme
  * bonus.
+ *
+ * `theme` may be null, which means "no team theme is known" and not
+ * "balanced" -- Balanced is a theme of its own. A null theme collapses the
+ * scale to tiers 2 and 4, class match or nothing, which is all that can
+ * honestly be said without it. Only Upgrade Gear passes null: it decides
+ * the order in which worn mythics are fed, and a coarser order costs
+ * nothing that a wrong one would. The two equip buttons must not, because
+ * equipping on a guessed theme puts the wrong item on.
  */
 function gearTier(item, playerClass, theme, mode) {
     if (item.rarity !== 'mythic')
@@ -20209,7 +20217,7 @@ function gearTier(item, playerClass, theme, mode) {
     if (mode === 'current' && item.level < MYTHIC_MAX_LEVEL)
         return 5;
     const c = classMatches(item, playerClass);
-    const t = themeMatches(item, theme);
+    const t = theme !== null && themeMatches(item, theme);
     if (c && t)
         return 1;
     if (c)
@@ -20509,6 +20517,12 @@ function upgradePageUrl(target) {
  * Ordered by priority tier so the material goes into the slot that gains
  * the most from it: a mythic matching class and theme grows both bonuses,
  * one matching nothing grows nothing that counts.
+ *
+ * `theme` may be null. What gets upgraded does not depend on it -- the
+ * filter is "worn, mythic, below the cap", and the player wears what the
+ * player wears. The theme only sharpens the order, so without one the list
+ * is ordered by class match and slot and the work still happens. Refusing
+ * to run would withhold the whole feature over a detail of sorting.
  */
 function pickUpgradeTargets(items, playerClass, theme) {
     return items
@@ -20649,6 +20663,12 @@ const STALE_QUEUE_MS = 90000;
  *  armors, so this has to allow a lot of passes; it bounds a changed page,
  *  not a normal inventory. */
 const MAX_MATERIAL_SCROLLS = 60;
+/** How many scroll passes between two Auto Select attempts while the list is
+ *  still filling. Asking after every pass would add its own wait to each of
+ *  the 60, which is the cost paid in the case that needs the passes least --
+ *  the one where the material never suffices. Asking every fifth pass ends
+ *  the common case within seconds and adds twelve attempts to the rare one. */
+const AUTO_SELECT_EVERY = 5;
 /** How often the market page may re-open the same head before giving up on
  *  it. Two chances, because the first may be the hand-off after the game's
  *  own redirect and the second a genuine retry; a third means the page is
@@ -21301,15 +21321,12 @@ class EquipmentGear {
                 return;
             EquipmentGear.running = true;
             try {
+                // A missing theme does not stop this button. What gets upgraded
+                // is what the player is wearing, and that is known without a
+                // team; the theme only sharpens the order. The equip buttons do
+                // stop, because they choose items and a guessed theme would put
+                // the wrong one on -- this one only chooses a sequence.
                 const theme = EquipmentGear.resolveTheme();
-                if (!theme) {
-                    EquipmentGear.showMessage('Upgrade Gear', 'No team theme known yet. Open your team page once ("Change team" on the'
-                        + ' league page) -- nothing needs to be built, the theme is read on the way in.'
-                        + ' Without it the tiers below would be guesses, and material spent on the wrong'
-                        + ' slot is gone.');
-                    logHHAuto('Gear: Upgrade Gear aborted, no team theme. Nothing was changed.');
-                    return;
-                }
                 const rawClass = Number(HeroHelper.getClass());
                 if (rawClass !== 1 && rawClass !== 2 && rawClass !== 3) {
                     EquipmentGear.showMessage('Upgrade Gear', 'Could not read the hero class.');
@@ -21325,12 +21342,14 @@ class EquipmentGear {
                 const targets = pickUpgradeTargets(all, rawClass, theme);
                 const stock = countMaterialStock(all);
                 logHHAuto(`Gear [Upgrade Gear]: ${targets.length} worn mythic(s) below level ${(/* inlined export .MYTHIC_MAX_LEVEL */20)},`
-                    + ` material stock ${stock.legendary} legendary + ${stock.epic} epic.`);
+                    + ` material stock ${stock.legendary} legendary + ${stock.epic} epic.`
+                    + (theme ? ` Order by team theme "${theme}" and class.`
+                        : ' No team theme known, so the order is by class match and slot only.'));
                 for (const t of targets) {
                     logHHAuto(`  Slot ${t.slot} (${SLOT_NAMES[t.slot]}): ${t.name} at level ${t.level}`
                         + ` [${TIER_NAMES[t.tier]}]`);
                 }
-                EquipmentGear.showUpgradePlan(targets, stock);
+                EquipmentGear.showUpgradePlan(targets, stock, theme);
             }
             catch (err) {
                 logHHAuto('Gear: Upgrade Gear failed before any change was made: ' + err);
@@ -21341,7 +21360,7 @@ class EquipmentGear {
             }
         });
     }
-    static showUpgradePlan(targets, stock) {
+    static showUpgradePlan(targets, stock, theme) {
         if (targets.length === 0) {
             EquipmentGear.showMessage('Upgrade Gear', `<p>Every mythic you are wearing is already at level ${(/* inlined export .MYTHIC_MAX_LEVEL */20)}.</p>`
                 + '<p style="color:#aaa;">Put the items you want to develop on first'
@@ -21355,6 +21374,10 @@ class EquipmentGear {
         <div id="HHGearPreview" style="padding:10px;max-width:720px;font-size:13px;">
             <p>Worn mythics below level ${(/* inlined export .MYTHIC_MAX_LEVEL */20)}, best-matching first &mdash;
                material goes where it grows the most resonance.</p>
+            ${theme ? '' : `<p style="color:#aaa;">No team theme known, so the order below only
+               separates items that match your class from those that do not. Every worn mythic
+               is upgraded either way. Open your team page once ("Change team" on the league
+               page) and the theme sharpens the order next time.</p>`}
             <table>
                 <tr><th>Slot</th><th>Item</th><th>level</th><th>why it is worth it</th></tr>
                 ${rows}
@@ -21439,7 +21462,8 @@ class EquipmentGear {
         return out;
     }
     /**
-     * Scroll the material list until the game stops adding to it.
+     * Scroll the material list until Auto Select can cover the next level, or
+     * until the game stops adding to it.
      *
      * The list is paged and the game loads the next batch only in answer to a
      * scroll -- it never fills itself (confirmed on the live page; the counts
@@ -21447,11 +21471,22 @@ class EquipmentGear {
      * the end). Auto Select chooses among the rendered pieces, so everything
      * beyond the first batch is invisible to it until this has run.
      *
+     * It stops at "enough", not at "everything". Scrolling the list to its
+     * end regardless was the whole cost of a level: the requirement is
+     * usually covered a few batches in, and the remaining passes bought
+     * nothing while the player watched the page scroll. Every item in the
+     * queue paid it again on its own page, which is where the minutes came
+     * from. Auto Select is therefore asked again while the list grows, and
+     * the first time the game lights up Level-up the scrolling ends.
+     *
      * Two idle passes before stopping, not one: a batch that is still in
      * flight when the first pass is counted would otherwise end the loading
      * early, and stopping early is exactly the failure this exists to remove.
+     *
+     * `enough` is the game's verdict, not a count: nothing here weighs
+     * material or reimplements the cost curve.
      */
-    static loadAllMaterial() {
+    static loadMaterialUntilEnough() {
         return EquipmentGear_awaiter(this, void 0, void 0, function* () {
             var _a, _b;
             let count = EquipmentGear.countMaterialSlots();
@@ -21465,16 +21500,21 @@ class EquipmentGear {
                 const now = EquipmentGear.countMaterialSlots();
                 if (now === count) {
                     if (++idle >= 2)
-                        return count;
+                        return { count, enough: EquipmentGear.levelUpEnabled() };
+                    continue;
                 }
-                else {
-                    idle = 0;
-                    count = now;
+                idle = 0;
+                count = now;
+                if (pass % AUTO_SELECT_EVERY === AUTO_SELECT_EVERY - 1) {
+                    $('#auto-select').trigger('click');
+                    yield new Promise(r => setTimeout(r, randomInterval(700, 1200)));
+                    if (EquipmentGear.levelUpEnabled())
+                        return { count, enough: true };
                 }
             }
             logHHAuto(`Gear: stopped scrolling the material list at ${count} piece(s) after`
                 + ` ${MAX_MATERIAL_SCROLLS} passes; it was still growing.`);
-            return count;
+            return { count, enough: EquipmentGear.levelUpEnabled() };
         });
     }
     /**
@@ -21560,13 +21600,11 @@ class EquipmentGear {
                         // requirement is largest and the first batch no longer
                         // carries it.
                         const before = EquipmentGear.countMaterialSlots();
-                        const after = yield EquipmentGear.loadAllMaterial();
-                        if (after > before) {
-                            logHHAuto(`Gear: material list grew from ${before} to ${after} piece(s)`
-                                + ' after scrolling; asking Auto Select again.');
-                            $('#auto-select').trigger('click');
-                            yield new Promise(r => setTimeout(r, randomInterval(700, 1200)));
-                        }
+                        const loaded = yield EquipmentGear.loadMaterialUntilEnough();
+                        logHHAuto(`Gear: material list ${before} -> ${loaded.count} piece(s) after`
+                            + (loaded.enough
+                                ? ' scrolling; Auto Select covers the next level.'
+                                : ' scrolling; still not enough for the next level.'));
                     }
                     const verdict = decideNextLevelUp({
                         currentLevel: startLevel + performed,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.12.3",
+  "version": "8.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.12.3",
+      "version": "8.12.5",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hhauto",
-  "version": "8.12.5",
+  "version": "8.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hhauto",
-      "version": "8.12.5",
+      "version": "8.12.4",
       "license": "GPL-3.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.4",
+  "version": "8.12.5",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.3",
+  "version": "8.12.4",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.12.5",
+  "version": "8.12.4",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/EquipmentUpgradeService.spec.ts
+++ b/spec/Service/EquipmentUpgradeService.spec.ts
@@ -61,6 +61,21 @@ describe('pickUpgradeTargets', () => {
         expect(targets.map(t => t.tier)).toEqual([1, 2, 4]);
     });
 
+    // Upgrading is about the items the player already wears, and those are
+    // known without a team. A missing theme may only coarsen the order.
+    it('still returns every worn mythic when no team theme is known', () => {
+        const both = item({ rarity: 'mythic', level: 5, equipped: true, slot: 1, classId: '3', themeId: 'sun', name: 'both' });
+        const themeOnly = item({ rarity: 'mythic', level: 5, equipped: true, slot: 2, classId: '1', themeId: 'sun', name: 'theme' });
+        const classOnly = item({ rarity: 'mythic', level: 5, equipped: true, slot: 3, classId: '3', themeId: 'fire', name: 'class' });
+
+        const targets = pickUpgradeTargets([both, themeOnly, classOnly], KNOW_HOW, null);
+
+        // Without a theme the scale collapses to "matches my class" and
+        // "does not"; nothing claims a theme match it cannot know.
+        expect(targets.map(t => t.name)).toEqual(['both', 'class', 'theme']);
+        expect(targets.map(t => t.tier)).toEqual([2, 2, 4]);
+    });
+
     it('judges the tier by what the item will be, not what it is', () => {
         // A level-1 mythic is tier 5 today but tier 1 once levelled, and
         // levelling it is the whole point.

--- a/src/Module/EquipmentGear.ts
+++ b/src/Module/EquipmentGear.ts
@@ -61,11 +61,36 @@ import { TK } from "../config/StorageKeys";
  *  side of infinity keeps a changed response shape from looping forever. */
 const MAX_INVENTORY_PAGES = 120;
 
-interface UpgradeQueueEntry { id: number; name: string; slot: number; startedAt?: number }
+/** One queued item.
+ *
+ *  `tries` is what bounds the hand-off between the two pages. At the cap the
+ *  game navigates off the upgrade page by itself, so the queue is handed on
+ *  from the market instead, and a head that cannot be opened at all would
+ *  otherwise bounce between the two forever. */
+interface UpgradeQueueEntry {
+    id: number;
+    name: string;
+    slot: number;
+    startedAt?: number;
+    tries?: number;
+}
 
 /** How long a queue may sit untouched before the market page forgets it.
  *  Long enough to survive the navigation the Start button triggers. */
 const STALE_QUEUE_MS = 90_000;
+
+/** How often the market list may be scrolled before accepting that nothing
+ *  more arrives. The game pages it in batches (measured: 100 slots on
+ *  arrival, 299 after scrolling to the end) and the test account held 1614
+ *  armors, so this has to allow a lot of passes; it bounds a changed page,
+ *  not a normal inventory. */
+const MAX_MATERIAL_SCROLLS = 60;
+
+/** How often the market page may re-open the same head before giving up on
+ *  it. Two chances, because the first may be the hand-off after the game's
+ *  own redirect and the second a genuine retry; a third means the page is
+ *  not opening at all. */
+const MAX_QUEUE_HEAD_TRIES = 3;
 
 const SLOT_NAMES: Record<number, string> = {
     1: 'Head', 2: 'Body', 3: 'Legs', 4: 'Flag', 5: 'Pet', 6: 'Weapon',
@@ -93,7 +118,7 @@ export class EquipmentGear {
     static moduleGearActions(): void {
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDShop")) return;
 
-        EquipmentGear.dropStaleUpgradeQueue();
+        EquipmentGear.resumeUpgradeQueue();
         EquipmentGear.watchTabSwitch();
 
         // The player's own inventory has its own tab strip
@@ -180,25 +205,68 @@ export class EquipmentGear {
     }
 
     /**
-     * Forget an upgrade queue that is no longer being worked on.
+     * Carry an upgrade run on from the market page, or forget it.
      *
-     * At the cap the game redirects off the upgrade page by itself, so the
-     * loop never reaches its own clean-up and the queue would sit in storage
-     * until the player happened to open an upgrade page again. Being back on
-     * the market with an old queue means the run is over one way or another.
-     * The age check is what keeps this from eating the queue the Start button
-     * just wrote, one navigation earlier.
+     * The market is where a run both starts and lands: at the cap the game
+     * navigates off the upgrade page by itself, so the hand-off to the next
+     * item cannot happen there -- the upgrade page writes the remaining queue
+     * before it triggers that redirect, and this opens whatever it left. The
+     * Start button leaves the same state behind, so both cases are one code
+     * path.
+     *
+     * An old queue is dropped instead: being back here with one means the run
+     * is over one way or another. The age check is what keeps that from
+     * eating the queue the Start button just wrote, one navigation earlier.
      */
-    private static dropStaleUpgradeQueue(): void {
+    private static resumeUpgradeQueue(): void {
+        if (EquipmentGear.resumeNavigating) return;
         const queue = getStoredJSON<UpgradeQueueEntry[]>(HHStoredVarPrefixKey + TK.gearUpgradeQueue, []);
         if (!Array.isArray(queue) || queue.length === 0) return;
+
         const startedAt = Number(queue[0]?.startedAt) || 0;
-        if (Date.now() - startedAt < STALE_QUEUE_MS) return;
-        setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
-        EquipmentGear.releaseAutoLoop();
-        logHHAuto(`Gear: dropping a stale upgrade queue (${queue.length} item(s) left);`
-            + ' the run is no longer on the upgrade page.');
+        if (Date.now() - startedAt >= STALE_QUEUE_MS) {
+            setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
+            EquipmentGear.releaseAutoLoop();
+            logHHAuto(`Gear: dropping a stale upgrade queue (${queue.length} item(s) left);`
+                + ' the run is no longer on the upgrade page.');
+            return;
+        }
+
+        const head = queue[0];
+        const tries = (Number(head.tries) || 0) + 1;
+        if (tries > MAX_QUEUE_HEAD_TRIES) {
+            // The upgrade page for this item does not open -- it bounces
+            // straight back here, so nothing was spent on it. Skipping it is
+            // the only way the rest of the queue gets its turn.
+            const rest = queue.slice(1);
+            logHHAuto(`Gear: ${head.name} (slot ${head.slot}) did not open after`
+                + ` ${MAX_QUEUE_HEAD_TRIES} attempt(s); skipping it,`
+                + ` ${rest.length} item(s) left.`);
+            if (rest.length === 0) {
+                setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');
+                EquipmentGear.releaseAutoLoop();
+                logHHAuto('Gear: upgrade run finished -- nothing left to open.');
+                return;
+            }
+            setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue,
+                JSON.stringify(rest.map(r => ({ ...r, startedAt: Date.now(), tries: 0 }))));
+            EquipmentGear.resumeNavigating = true;
+            EquipmentGear.gotoUpgradePage(rest[0].id);
+            return;
+        }
+
+        setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue,
+            JSON.stringify([{ ...head, tries }, ...queue.slice(1)]));
+        logHHAuto(`Gear: upgrade run continues with ${head.name} (slot ${head.slot});`
+            + ` ${queue.length} item(s) left.`);
+        EquipmentGear.resumeNavigating = true;
+        EquipmentGear.gotoUpgradePage(head.id);
     }
+
+    /** One navigation per page load. The market handler runs on every autoloop
+     *  tick, and `location.href` does not take effect before the next one --
+     *  without this the retry budget would be spent waiting for the browser. */
+    private static resumeNavigating = false;
 
     private static tabWatcherBound = false;
 
@@ -765,11 +833,13 @@ export class EquipmentGear {
             </table>
             <p><b>Material:</b> ${stock.legendary.toLocaleString()} legendary and
                ${stock.epic.toLocaleString()} epic items. Mythics are never consumed.</p>
-            <p style="color:#aaa;font-size:11px;">The upgrade page shows each item's exact
+            <p style="color:#aaa;font-size:11px;">One item is taken to level ${MYTHIC_MAX_LEVEL}
+               before the next one starts. The upgrade page states each item's exact
                requirement, and the run stops by itself once the material is spent.</p>
             <p id="HHGearStatus" style="color:#ffb827;"></p>
             <label class="myButton" id="HHGearUpgradeStart" style="font-size:14px;width:100%;text-align:center;">
-                Start with ${esc(targets[0].name)} (slot ${targets[0].slot})</label>
+                Level all ${targets.length} item(s), starting with ${esc(targets[0].name)}
+                (slot ${targets[0].slot})</label>
         </div>`);
 
         $('#HHGearUpgradeStart').on('click', function () {
@@ -814,14 +884,85 @@ export class EquipmentGear {
         return window.location.pathname.indexOf(UPGRADE_PATH) !== -1;
     }
 
+    /** The game's own verdict on whether the picked material covers the next
+     *  level. Read fresh every time: Auto Select and a scroll both change it. */
+    private static levelUpEnabled(): boolean {
+        const button = document.getElementById('level-up') as HTMLButtonElement | null;
+        return button !== null && !button.disabled;
+    }
+
+    /** Material pieces the page has rendered so far. This is the number Auto
+     *  Select works from, not the number the account owns. */
+    private static countMaterialSlots(): number {
+        return document.querySelectorAll('.slot[data-d]').length;
+    }
+
+    /**
+     * The elements that actually scroll the material list.
+     *
+     * Anchored on the list and walked upwards rather than named by a fixed
+     * selector: whether the overflow sits on `.items-container` itself or on
+     * an ancestor is the page's business, and the window is included because
+     * a list that fills the document scrolls with it.
+     */
+    private static materialScrollTargets(): HTMLElement[] {
+        const out: HTMLElement[] = [];
+        let el = document.querySelector('.items-container') as HTMLElement | null;
+        while (el !== null) {
+            if (el.scrollHeight > el.clientHeight + 20) {
+                const overflow = getComputedStyle(el).overflowY;
+                if (overflow === 'auto' || overflow === 'scroll') out.push(el);
+            }
+            el = el.parentElement;
+        }
+        return out;
+    }
+
+    /**
+     * Scroll the material list until the game stops adding to it.
+     *
+     * The list is paged and the game loads the next batch only in answer to a
+     * scroll -- it never fills itself (confirmed on the live page; the counts
+     * measured earlier were 100 slots on arrival and 299 after scrolling to
+     * the end). Auto Select chooses among the rendered pieces, so everything
+     * beyond the first batch is invisible to it until this has run.
+     *
+     * Two idle passes before stopping, not one: a batch that is still in
+     * flight when the first pass is counted would otherwise end the loading
+     * early, and stopping early is exactly the failure this exists to remove.
+     */
+    private static async loadAllMaterial(): Promise<number> {
+        let count = EquipmentGear.countMaterialSlots();
+        let idle = 0;
+        for (let pass = 0; pass < MAX_MATERIAL_SCROLLS; pass++) {
+            for (const target of EquipmentGear.materialScrollTargets()) {
+                target.scrollTop = target.scrollHeight;
+            }
+            window.scrollTo(0, document.scrollingElement?.scrollHeight ?? 0);
+            await new Promise(r => setTimeout(r, randomInterval(600, 900)));
+
+            const now = EquipmentGear.countMaterialSlots();
+            if (now === count) {
+                if (++idle >= 2) return count;
+            } else {
+                idle = 0;
+                count = now;
+            }
+        }
+        logHHAuto(`Gear: stopped scrolling the material list at ${count} piece(s) after`
+            + ` ${MAX_MATERIAL_SCROLLS} passes; it was still growing.`);
+        return count;
+    }
+
     /**
      * Work the queue on the upgrade page: Auto Select, then Level-up, until
      * the item is capped or the material runs out.
      *
      * Auto Select is the game's own material picker, and the Level-up button
-     * only lights up once it has covered the requirement -- so a button that
-     * stays disabled is the game telling us the stock is spent. Nothing here
-     * counts material or reimplements the cost curve.
+     * only lights up once it has covered the requirement. Nothing here counts
+     * material or reimplements the cost curve -- but a dark button is only
+     * believed once the whole material list has been scrolled into the page,
+     * because Auto Select can pick only from what is rendered.
      *
      * Does nothing at all while the queue is empty, which is the state
      * unless the player pressed the button.
@@ -864,22 +1005,66 @@ export class EquipmentGear {
             // value is the only reliable level here. Over-counting a failed
             // call only makes this stop early, which is the safe direction.
             const startLevel = Number(unsafeWindow.item_to_upgrade?.level) || 0;
+            const rest = queue.slice(1);
+
+            /** Hand the queue on before the level that reaches the cap, not
+             *  after: the game navigates off this page the moment an item is
+             *  capped, so nothing below that click is guaranteed to run. The
+             *  market page finds the next item waiting and opens it. When this
+             *  was the last item there is no next page to clean up either, so
+             *  the clean-up happens here too. */
+            let handedOver = false;
+            const handOver = (lastMsg: string) => {
+                if (handedOver) return;
+                handedOver = true;
+                if (rest.length === 0) {
+                    finish(lastMsg);
+                    return;
+                }
+                setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue,
+                    JSON.stringify(rest.map(r => ({ ...r, startedAt: Date.now(), tries: 0 }))));
+                logHHAuto(`Gear: moving on to ${rest[0].name} (slot ${rest[0].slot}).`);
+            };
+
             let performed = 0;
             for (;;) {
                 $('#auto-select').trigger('click');
                 await new Promise(r => setTimeout(r, randomInterval(700, 1200)));
 
-                const enabled = $('#level-up').length > 0
-                    && !(document.getElementById('level-up') as HTMLButtonElement).disabled;
+                if (!EquipmentGear.levelUpEnabled()) {
+                    // A disabled button is not proof that the material is
+                    // spent. The game renders the material list in batches and
+                    // loads the next one only while it is scrolled, and Auto
+                    // Select picks from what is rendered -- so an unscrolled
+                    // list reads as "not enough material" for a level the
+                    // stock covers. It shows up around 19 -> 20, where the
+                    // requirement is largest and the first batch no longer
+                    // carries it.
+                    const before = EquipmentGear.countMaterialSlots();
+                    const after = await EquipmentGear.loadAllMaterial();
+                    if (after > before) {
+                        logHHAuto(`Gear: material list grew from ${before} to ${after} piece(s)`
+                            + ' after scrolling; asking Auto Select again.');
+                        $('#auto-select').trigger('click');
+                        await new Promise(r => setTimeout(r, randomInterval(700, 1200)));
+                    }
+                }
+
                 const verdict = decideNextLevelUp({
-                    currentLevel: startLevel + performed, levelUpEnabled: enabled,
+                    currentLevel: startLevel + performed,
+                    levelUpEnabled: EquipmentGear.levelUpEnabled(),
                 });
                 if (!verdict.go) {
                     logHHAuto(`Gear: stopping on ${head.name} after ${performed} level(s) -- ${verdict.reason}.`);
                     if (!verdict.done) { finish(verdict.reason); return; }
+                    handOver('every queued item is done.');
                     break;
                 }
 
+                if (startLevel + performed + 1 >= MYTHIC_MAX_LEVEL) {
+                    handOver(`${head.name} reaches level ${MYTHIC_MAX_LEVEL}`
+                        + ' with the level-up going out now.');
+                }
                 $('#level-up').trigger('click');
                 performed++;
                 await new Promise(r => setTimeout(r, randomInterval(1500, 2500)));
@@ -887,11 +1072,7 @@ export class EquipmentGear {
                     + ` (${performed} level(s) this run).`);
             }
 
-            const rest = queue.slice(1);
-            if (rest.length === 0) { finish('every queued item is done.'); return; }
-            setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue,
-                JSON.stringify(rest.map(r => ({ ...r, startedAt: Date.now() }))));
-            logHHAuto(`Gear: moving on to ${rest[0].name} (slot ${rest[0].slot}).`);
+            if (rest.length === 0) return;
             EquipmentGear.gotoUpgradePage(rest[0].id);
         } catch (err) {
             setStoredValue(HHStoredVarPrefixKey + TK.gearUpgradeQueue, '[]');

--- a/src/Module/EquipmentGear.ts
+++ b/src/Module/EquipmentGear.ts
@@ -86,6 +86,13 @@ const STALE_QUEUE_MS = 90_000;
  *  not a normal inventory. */
 const MAX_MATERIAL_SCROLLS = 60;
 
+/** How many scroll passes between two Auto Select attempts while the list is
+ *  still filling. Asking after every pass would add its own wait to each of
+ *  the 60, which is the cost paid in the case that needs the passes least --
+ *  the one where the material never suffices. Asking every fifth pass ends
+ *  the common case within seconds and adds twelve attempts to the rare one. */
+const AUTO_SELECT_EVERY = 5;
+
 /** How often the market page may re-open the same head before giving up on
  *  it. Two chances, because the first may be the hand-off after the game's
  *  own redirect and the second a genuine retry; a third means the page is
@@ -764,16 +771,12 @@ export class EquipmentGear {
         if (EquipmentGear.running) return;
         EquipmentGear.running = true;
         try {
+            // A missing theme does not stop this button. What gets upgraded
+            // is what the player is wearing, and that is known without a
+            // team; the theme only sharpens the order. The equip buttons do
+            // stop, because they choose items and a guessed theme would put
+            // the wrong one on -- this one only chooses a sequence.
             const theme = EquipmentGear.resolveTheme();
-            if (!theme) {
-                EquipmentGear.showMessage('Upgrade Gear',
-                    'No team theme known yet. Open your team page once ("Change team" on the'
-                    + ' league page) -- nothing needs to be built, the theme is read on the way in.'
-                    + ' Without it the tiers below would be guesses, and material spent on the wrong'
-                    + ' slot is gone.');
-                logHHAuto('Gear: Upgrade Gear aborted, no team theme. Nothing was changed.');
-                return;
-            }
             const rawClass = Number(HeroHelper.getClass());
             if (rawClass !== 1 && rawClass !== 2 && rawClass !== 3) {
                 EquipmentGear.showMessage('Upgrade Gear', 'Could not read the hero class.');
@@ -792,13 +795,15 @@ export class EquipmentGear {
             const stock = countMaterialStock(all);
 
             logHHAuto(`Gear [Upgrade Gear]: ${targets.length} worn mythic(s) below level ${MYTHIC_MAX_LEVEL},`
-                + ` material stock ${stock.legendary} legendary + ${stock.epic} epic.`);
+                + ` material stock ${stock.legendary} legendary + ${stock.epic} epic.`
+                + (theme ? ` Order by team theme "${theme}" and class.`
+                    : ' No team theme known, so the order is by class match and slot only.'));
             for (const t of targets) {
                 logHHAuto(`  Slot ${t.slot} (${SLOT_NAMES[t.slot]}): ${t.name} at level ${t.level}`
                     + ` [${TIER_NAMES[t.tier]}]`);
             }
 
-            EquipmentGear.showUpgradePlan(targets, stock);
+            EquipmentGear.showUpgradePlan(targets, stock, theme);
         } catch (err) {
             logHHAuto('Gear: Upgrade Gear failed before any change was made: ' + err);
             EquipmentGear.showMessage('Upgrade Gear', 'Failed, nothing was changed. See the log.');
@@ -810,6 +815,7 @@ export class EquipmentGear {
     private static showUpgradePlan(
         targets: UpgradeTarget[],
         stock: { legendary: number; epic: number; other: number },
+        theme: GearTheme | null,
     ): void {
         if (targets.length === 0) {
             EquipmentGear.showMessage('Upgrade Gear',
@@ -827,6 +833,10 @@ export class EquipmentGear {
         <div id="HHGearPreview" style="padding:10px;max-width:720px;font-size:13px;">
             <p>Worn mythics below level ${MYTHIC_MAX_LEVEL}, best-matching first &mdash;
                material goes where it grows the most resonance.</p>
+            ${theme ? '' : `<p style="color:#aaa;">No team theme known, so the order below only
+               separates items that match your class from those that do not. Every worn mythic
+               is upgraded either way. Open your team page once ("Change team" on the league
+               page) and the theme sharpens the order next time.</p>`}
             <table>
                 <tr><th>Slot</th><th>Item</th><th>level</th><th>why it is worth it</th></tr>
                 ${rows}
@@ -919,7 +929,8 @@ export class EquipmentGear {
     }
 
     /**
-     * Scroll the material list until the game stops adding to it.
+     * Scroll the material list until Auto Select can cover the next level, or
+     * until the game stops adding to it.
      *
      * The list is paged and the game loads the next batch only in answer to a
      * scroll -- it never fills itself (confirmed on the live page; the counts
@@ -927,11 +938,22 @@ export class EquipmentGear {
      * the end). Auto Select chooses among the rendered pieces, so everything
      * beyond the first batch is invisible to it until this has run.
      *
+     * It stops at "enough", not at "everything". Scrolling the list to its
+     * end regardless was the whole cost of a level: the requirement is
+     * usually covered a few batches in, and the remaining passes bought
+     * nothing while the player watched the page scroll. Every item in the
+     * queue paid it again on its own page, which is where the minutes came
+     * from. Auto Select is therefore asked again while the list grows, and
+     * the first time the game lights up Level-up the scrolling ends.
+     *
      * Two idle passes before stopping, not one: a batch that is still in
      * flight when the first pass is counted would otherwise end the loading
      * early, and stopping early is exactly the failure this exists to remove.
+     *
+     * `enough` is the game's verdict, not a count: nothing here weighs
+     * material or reimplements the cost curve.
      */
-    private static async loadAllMaterial(): Promise<number> {
+    private static async loadMaterialUntilEnough(): Promise<{ count: number; enough: boolean }> {
         let count = EquipmentGear.countMaterialSlots();
         let idle = 0;
         for (let pass = 0; pass < MAX_MATERIAL_SCROLLS; pass++) {
@@ -943,15 +965,21 @@ export class EquipmentGear {
 
             const now = EquipmentGear.countMaterialSlots();
             if (now === count) {
-                if (++idle >= 2) return count;
-            } else {
-                idle = 0;
-                count = now;
+                if (++idle >= 2) return { count, enough: EquipmentGear.levelUpEnabled() };
+                continue;
+            }
+            idle = 0;
+            count = now;
+
+            if (pass % AUTO_SELECT_EVERY === AUTO_SELECT_EVERY - 1) {
+                $('#auto-select').trigger('click');
+                await new Promise(r => setTimeout(r, randomInterval(700, 1200)));
+                if (EquipmentGear.levelUpEnabled()) return { count, enough: true };
             }
         }
         logHHAuto(`Gear: stopped scrolling the material list at ${count} piece(s) after`
             + ` ${MAX_MATERIAL_SCROLLS} passes; it was still growing.`);
-        return count;
+        return { count, enough: EquipmentGear.levelUpEnabled() };
     }
 
     /**
@@ -1041,13 +1069,11 @@ export class EquipmentGear {
                     // requirement is largest and the first batch no longer
                     // carries it.
                     const before = EquipmentGear.countMaterialSlots();
-                    const after = await EquipmentGear.loadAllMaterial();
-                    if (after > before) {
-                        logHHAuto(`Gear: material list grew from ${before} to ${after} piece(s)`
-                            + ' after scrolling; asking Auto Select again.');
-                        $('#auto-select').trigger('click');
-                        await new Promise(r => setTimeout(r, randomInterval(700, 1200)));
-                    }
+                    const loaded = await EquipmentGear.loadMaterialUntilEnough();
+                    logHHAuto(`Gear: material list ${before} -> ${loaded.count} piece(s) after`
+                        + (loaded.enough
+                            ? ' scrolling; Auto Select covers the next level.'
+                            : ' scrolling; still not enough for the next level.'));
                 }
 
                 const verdict = decideNextLevelUp({

--- a/src/Service/EquipmentOptimizerService.ts
+++ b/src/Service/EquipmentOptimizerService.ts
@@ -308,17 +308,25 @@ function resonancePoints(
  * Tier 5 also holds every legendary and epic. Those carry no resonance at
  * all: of the 12 legendary slots in the league, none had a class or theme
  * bonus.
+ *
+ * `theme` may be null, which means "no team theme is known" and not
+ * "balanced" -- Balanced is a theme of its own. A null theme collapses the
+ * scale to tiers 2 and 4, class match or nothing, which is all that can
+ * honestly be said without it. Only Upgrade Gear passes null: it decides
+ * the order in which worn mythics are fed, and a coarser order costs
+ * nothing that a wrong one would. The two equip buttons must not, because
+ * equipping on a guessed theme puts the wrong item on.
  */
 export function gearTier(
     item: ArmorItem,
     playerClass: PlayerClass,
-    theme: GearTheme,
+    theme: GearTheme | null,
     mode: GearMode,
 ): number {
     if (item.rarity !== 'mythic') return 5;
     if (mode === 'current' && item.level < MYTHIC_MAX_LEVEL) return 5;
     const c = classMatches(item, playerClass);
-    const t = themeMatches(item, theme);
+    const t = theme !== null && themeMatches(item, theme);
     if (c && t) return 1;
     if (c) return 2;
     if (t) return 3;

--- a/src/Service/EquipmentUpgradeService.ts
+++ b/src/Service/EquipmentUpgradeService.ts
@@ -57,11 +57,17 @@ export function upgradePageUrl(target: { id_member_armor: number }): string {
  * Ordered by priority tier so the material goes into the slot that gains
  * the most from it: a mythic matching class and theme grows both bonuses,
  * one matching nothing grows nothing that counts.
+ *
+ * `theme` may be null. What gets upgraded does not depend on it -- the
+ * filter is "worn, mythic, below the cap", and the player wears what the
+ * player wears. The theme only sharpens the order, so without one the list
+ * is ordered by class match and slot and the work still happens. Refusing
+ * to run would withhold the whole feature over a detail of sorting.
  */
 export function pickUpgradeTargets(
     items: ArmorItem[],
     playerClass: PlayerClass,
-    theme: GearTheme,
+    theme: GearTheme | null,
 ): UpgradeTarget[] {
     return items
         .filter(i => i.equipped && i.rarity === 'mythic' && i.level < MYTHIC_MAX_LEVEL)


### PR DESCRIPTION
Releases as **8.12.4** (main carries 8.12.3).

Three things stood between the button and the items the player wears.

## It required a team theme

The button refused to run until a team theme was known and sent the player to
the team page first. That was the wrong condition. What it upgrades is what
the player is wearing -- the filter is "worn, mythic, below the cap" -- and
that is known without a team. The theme only decides which of those worn
mythics is fed first. Withholding the whole feature over a detail of sorting
is a worse trade than a coarser order.

`gearTier` takes `GearTheme | null` for that. Null collapses the scale to
tiers 2 and 4, class match or nothing, which is all that can honestly be said
without a theme -- it does not silently read as Balanced, which is a theme of
its own. Only `pickUpgradeTargets` passes null. `planCurrentBest` and
`planPossibleBest` keep the requirement, because they choose items and a
guessed theme puts the wrong item on; that rationale is in the file head and
is unchanged.

## It scrolled the material list to the end, every time

The material list on the upgrade page is paged: the game renders a first batch
and loads the next only in answer to a scroll -- it never fills itself. Auto
Select picks from what is rendered, so once the first batch no longer covered
a level, the Level-up button stayed dark and the run read that as "the
material is spent". It showed up around level 19 to 20, where the requirement
is largest.

A dark button is now only believed after the list has been scrolled, and the
scrolling stops the first time the game lights up Level-up rather than at the
end of the list. Auto Select is asked again while the list grows -- every
fifth pass, so the case that needs the passes least does not pay a wait on
each of the sixty. Reported from the running game: it scrolled for minutes,
and every item in the queue paid it again on its own page.

A level the stock genuinely cannot cover still walks the whole list, because
that is the only way to know it cannot. `enough` is the game's own verdict,
read off the Level-up button -- nothing here weighs material or reimplements
the cost curve.

## It stopped after one item

At the cap the game navigates off the upgrade page by itself, so the code that
moved the queue on to the next item never ran; the queue sat in storage until
it aged out. The remaining queue is now written before the level that reaches
the cap, and the market page opens whatever is left.

## Gates

`typecheck`, `lint:ci`, 1505 tests, `deps:circular:check`, `check:gm-grants`,
`check:docs`, `check:headers`, `check:player-data`, `build`. New test: without
a theme all three worn mythics come back, tiers `[2, 2, 4]` -- none claims a
theme match it cannot know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
