### PR TITLE
Record the reorganisation, and why the suite stays on jest 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ Older entries below were migrated 1:1 from `README.md`.
 - An unused field removed from the simulator's player model.
 - Two unused selector constants removed; four code comments that described the
   game wrongly corrected.
+- The documentation is English throughout, and `docs-internal/` is now
+  `docs/reference/`: the name said "not for you" while holding what a
+  contributor needs. `CONTRIBUTING.md` carries the project's rules and states
+  which parts of the tree are committed and which stay local.
+- A dead model class and an export nobody imported removed. `webpack` was used
+  by the build without being declared and is a devDependency now.
+- Dependencies updated: five advisories in build tooling are gone, and jscpd,
+  source-map-loader and webpack-cli moved a major version. jest 30 and
+  TypeScript 7 were tried and rolled back -- jsdom 26 no longer lets a test
+  redefine `window.location`, and ts-loader does not run on the new compiler.
 
 ### v8.13.0 - Gates for a young account
 

--- a/docs/reference/test-strategy.md
+++ b/docs/reference/test-strategy.md
@@ -189,6 +189,20 @@ reverted:
   When HHauto starts sending one, its schema test goes into
   `spec/fixtures/<endpoint>/`, laid out like `live-blessings/`.
 
+## Why the suite still runs on jest 29
+
+jest 30 was tried on 2026-09-12 and rolled back: it brings jsdom 26, where
+`window.location` can no longer be redefined, and 395 of 1724 tests fail with
+`TypeError: Cannot redefine property: location`. Only two files cause it --
+`spec/testHelpers/MockHelpers.ts` and `spec/Service/PageNavigationService.spec.ts`
+-- but the helper sits in nearly every suite. Whoever takes the upgrade on
+replaces the redefinition there (a navigation facade the tests can stub, or
+`jest.replaceProperty`) and the rest follows.
+
+TypeScript 7 was tried the same day and rolled back for a different reason: the
+tooling is not there yet. `ts-loader` aborts the build and madge crashes the
+cycle check.
+
 ## Deliberately not done
 
 - Snapshot tests for HTML.


### PR DESCRIPTION
Documentation catching up with the last two merges.

- The internal section of v8.13.1 names what changed for contributors: the docs are English throughout, `docs-internal/` is `docs/reference/`, `CONTRIBUTING.md` carries the rules and the in-git/local split, dead code and an undeclared `webpack` dependency sorted, dependencies updated.
- `docs/reference/test-strategy.md` says why the suite still runs on jest 29 and what a future upgrade has to change: jsdom 26 no longer lets a test redefine `window.location`, and exactly two files rely on that. TypeScript 7 is noted with its own reason -- ts-loader and madge do not run on it yet.

No code changes.