### PR TITLE
docs: the battle model, the game surface and a concept for opponent-aware teams

### DIFF
--- a/docs/reference/bdsm-battle-simulator.md
+++ b/docs/reference/bdsm-battle-simulator.md
@@ -13,6 +13,59 @@ BDSMHelper.ts, BDSMPlayer.ts, BDSMSimu.ts).
 
 ---
 
+## Measured against a real fight (2026-09-12)
+
+One league fight on the test account, with the answer's `rounds` read hit by
+hit. Our side: damage 19,773, defense 6,957, ego 122,765, chance 13,448, theme
+water. The opponent: damage 13,418, defense 5,884, ego 109,538, chance 8,572,
+no theme (balanced). Both come from `opponents_list` on `/leagues.html`, which
+is where the simulator reads them.
+
+| What the model says | What the game did | Verdict |
+|---|---|---|
+| base damage `atk - adv_def` | the opponent hit 13,418 - 6,957 = 6,461, on every normal hit | exact |
+| our base damage | 16,854 per hit, which is (19,773 x 1.15) - 5,884 | exact **once the equipped mythic booster is counted**, see below |
+| crit = `2 + critDamage synergy` | our crit 33,885 = 16,854 x 2.0105, and our critDamage synergy is 0.0105; the opponent's crit was exactly 2x with a synergy of 0 | exact |
+| heal on hit | after each of our hits the ego rose by `ceil(0.095 x damage)` -- 1,602 after a normal hit, 3,220 after the crit -- capped at the maximum, which is why the first heal is invisible | exact, all six rounds reproduce |
+| points on a win | 92,033 of 122,773 ego left = 0.7496 -> 15 + ceil(7.496) = 23, and the game awarded 23 | exact |
+| the whole prediction | 100 % win, expected value 22.2; the fight gave 23 | consistent (the fight before: 22.1 predicted, 22 given) |
+
+### The one gap: the equipped mythic booster
+
+The `damage` in `opponents_list` does not include the mythic booster. MB2
+("All Mastery's Emblem", +15 % damage in league and season) was equipped with
+16 of 100 uses left, and the game hit for `19,773 x 1.15` minus the opponent's
+defense -- 16,854.95, floored to 16,854. The simulator takes the list value and
+therefore models our own damage 15 % too low while such a booster is on: more
+rounds, less remaining ego, fewer points than the fight delivers. Whoever wants
+the prediction to match reality reads `Temp_boosterStatus` (`Booster.ts` keeps
+the equipped mythic there) and scales the attack accordingly.
+
+### What this fight could not show
+
+- **`defReduce` did not appear.** Both sides carried the sun synergy at 0.0435,
+  and both hits equal a full, unreduced subtraction of the defender's defense.
+  The values in `opponents_list` look like final values with the synergies
+  already worked in, while the simulator reduces our defense by the opponent's
+  `defReduce` again in league mode. One fight is not proof for every case, but
+  it is evidence that this step counts the same bonus twice.
+- **Domination** stayed untested: the opponent had no theme, so no element
+  matched.
+- The crit rate is not measurable from six hits. Ours computes to 0.3 x
+  13,448 / (13,448 + 8,572) + 0.0214 = 0.205, and one of six hits was critical.
+
+### How to read an opponent from this
+
+The four numbers that decide a league fight stand in `opponents_list` per
+opponent: `damage`, `defense`, `remaining_ego`, `chance`. Hits needed to win is
+`ceil(opponentEgo / (ourDamage - theirDefense))`, hits we survive is
+`ceil(ourEgo / (theirDamage - ourDefense))` -- with heal on hit stretching the
+second number. Crits shorten both, weighted by the chance share above. The
+points follow from the ego left, which is why a fight that is won quickly is
+worth nearly twice a fight that is barely won.
+
+---
+
 ## Files
 
 | File | Content |

--- a/docs/reference/bdsm-battle-simulator.md
+++ b/docs/reference/bdsm-battle-simulator.md
@@ -49,8 +49,16 @@ the equipped mythic there) and scales the attack accordingly.
   already worked in, while the simulator reduces our defense by the opponent's
   `defReduce` again in league mode. One fight is not proof for every case, but
   it is evidence that this step counts the same bonus twice.
-- **Domination** stayed untested: the opponent had no theme, so no element
-  matched.
+- **Domination is measured** -- in a second fight the same day, deliberately
+  against a fire-themed opponent while our team's theme was water (water
+  dominates fire). Our ego went into the fight at 135,293 against the 122,773
+  the list showed (factor 1.1020) and our attack at 25,074 against the boosted
+  22,739 (factor 1.1027): **+10 % on ego and attack, as the model says**. Our
+  defense, which gets no domination bonus, still differed from the list by
+  1.85 % -- that is how exact the list itself is, and it is the reason the two
+  factors come out at 1.102 rather than a clean 1.100. The fight was lost on
+  purpose: a losing fight shows the same per-hit numbers and costs one
+  challenge energy.
 - The crit rate is not measurable from six hits. Ours computes to 0.3 x
   13,448 / (13,448 + 8,572) + 0.0214 = 0.205, and one of six hits was critical.
 

--- a/docs/reference/bdsm-battle-simulator.md
+++ b/docs/reference/bdsm-battle-simulator.md
@@ -54,6 +54,30 @@ the equipped mythic there) and scales the attack accordingly.
 - The crit rate is not measurable from six hits. Ours computes to 0.3 x
   13,448 / (13,448 + 8,572) + 0.0214 = 0.205, and one of six hits was critical.
 
+### What the team scoring makes of it
+
+`TeamEvaluationService.computeEffectivePower` ranks our own candidate teams
+with `damage x expectedHit x (1 + sun) x ego x (1 + water)`. Held against the
+fight above, three things stand out (**inferred** from one measured fight, not
+proven across many):
+
+- **Our defense does not appear in the score at all.** In the measured fight it
+  took 6,957 off every incoming hit of 13,418 -- it halved the damage. Two
+  candidate teams with the same ego and different defense rank equal today,
+  although one survives nearly twice as long. What the score would need is
+  hits survived, `ego / (opponentDamage - ourDefense)`; the league list gives a
+  realistic `opponentDamage` for the account's own league, so the reference
+  value is readable rather than guessed.
+- **`ego x (1 + water)` stands in for heal on hit**, which in the fight was
+  `ceil(0.095 x damage dealt)` per hit -- it scales with our damage and the
+  number of rounds, not with ego.
+- **`(1 + sun)` multiplies our offence**, but the sun synergy is "decrease
+  defense of opponent", and no such reduction appeared in the fight. If the
+  list values are final, this factor rewards something the game does not do.
+
+`expectedHit = 1 - crit + crit x (2 + fire)` matches the measured crit exactly;
+that half of the formula is sound.
+
 ### How to read an opponent from this
 
 The four numbers that decide a league fight stand in `opponents_list` per

--- a/docs/reference/game-mechanics.md
+++ b/docs/reference/game-mechanics.md
@@ -323,7 +323,7 @@ wrong.
 | Identifier | Effect |
 |-----------|---------|
 | MB1 (Sandalwood) | more girl shards per battle |
-| MB2 (All Mastery's Emblem) | +15% damage in league and season for 100 performances |
+| MB2 (All Mastery's Emblem) | +15% damage in league and season for 100 performances. Measured 2026-09-12 in a league fight: the hit was `damage x 1.15 - the opponent's defense`, and the `damage` the league list shows does **not** include it |
 
 ### The recommendation (Performance Handbook)
 

--- a/docs/reference/game-surface-inventory.md
+++ b/docs/reference/game-surface-inventory.md
@@ -29,8 +29,14 @@ Everything that costs resources was left out, by these features:
 | a purchase or a pass | "Get Path of Valor Pass", `purchase-pass` |
 | a fight or energy | "Challenge!", "Perform!", `data-battles` |
 
-The run aborts as soon as a click lowers the koban balance. It did not abort:
-**not one of the 303 clicks cost a koban.**
+The run aborts as soon as a click lowers the koban balance -- and it did, on
+the shop page, for 42 kobans. The row that records it says "Boosters", and that
+label is wrong: the tool clicked by list index, the page had rebuilt its list
+after the previous click, and the index then pointed at the shop's
+**"Restock 42"** button. Measured again 2026-09-12, twice, for another 84
+kobans, until the tool was taught two things: a price counts even when it sits
+in the container around the element, and an index is re-checked against the
+element it was collected from before the click.
 
 ## The re-check (2026-09-11, level 115, world 5, 24 girls)
 
@@ -45,6 +51,24 @@ page except home -- the symbol only appears when there is something to report),
 `.nc-events-prize-locations-buttons-container` and `.redirect_button`. The
 "effect" column was **not** re-clicked; it remains the recording of
 2026-09-09.
+
+## Re-checked with clicks (2026-09-12, level 127, 24 girls)
+
+The tour ran again on the same account, 263 clicks, this time with the tool
+hardened (see above). **No identifier from the tables below has disappeared,
+and every page still answers with the `body[page=...]` the tables name.** The
+differences are all account state, not drift:
+
+| Page | What differs | Why |
+|---|---|---|
+| `/home.html` | `.feature-locked` for Clubs gone | the account has 24 girls now and is in a club |
+| `/activities.html?tab=missions` | 10 controls instead of 25, no `.mission_button` | no missions on offer at that moment |
+| `/member-progression.html` | `Claim` / `#claim-all` gone | nothing to collect |
+| `/pachinko.html` | the `10 games` button gone, other tiles present | the offer rotates |
+| `/god-path.html` | `.new_notif` gone | nothing new to report |
+| `/event.html`, `/characters.html` | fewer tiles | other events are running |
+| `.button-notification-icon` | missing on every page | it only exists while something is pending |
+| `/labyrinth-entrance.html` | answers `page=labyrinth` | a labyrinth is running, as the note above says |
 
 ## Pages that redirect to home
 
@@ -289,7 +313,7 @@ source in the interface -- the values themselves are in `shared.Hero.energies`
 | Boosters | `.market-menu-switch-tab` | no visible change |
 | Books | `.market-menu-switch-tab` | no visible change |
 | Gifts | `.market-menu-switch-tab` | no visible change |
-| Boosters | `.active` | KOBANS -42 |
+| Restock (recorded as "Boosters" through the index drift above) | `.active`, inside the merchant panel with `Restock 42` | KOBANS -42 -- refreshes the merchant's stock |
 
 ### `/pantheon.html`  (`body[page=pantheon]`, 11 elements)
 

--- a/docs/reference/live-verification-lessons.md
+++ b/docs/reference/live-verification-lessons.md
@@ -148,6 +148,31 @@ raids, an installed script would not.
 returns), not the bare name, and do not take a harness pass as proof for a
 bare-name read.
 
+**A reading across a page change needs three checks, not one.** A tool that
+compares the koban balance before and after a click reported a purchase of
+4,821 kobans; the balance had not moved. Three different states all look like
+"the number fell":
+
+| What was seen | What it was | How to tell |
+|---|---|---|
+| hero missing, game domain, page readable | a real logout | `shared.Hero.infos.id` plus the login anchor |
+| hero missing, foreign domain | the click followed an ad or app link | compare `location.host` with the game host |
+| page not readable at all | the page was navigating during the read | read again after a pause before concluding anything |
+
+Only the first is a finding. The other two are the tool measuring something
+that is not the game.
+
+**An index into a list of elements does not survive a click.** The same tour
+clicked by position, the page rebuilt its control list after each click, and
+the index then pointed at a neighbour -- in one case the shop's "Restock 42"
+button, which really did spend kobans while the log said "Boosters". Re-resolve
+the element by a stable key (tag, id, class, text) and skip it when the list
+has moved.
+
+**A price is often not in the element but in the box around it.** The same
+Restock button carries its koban icon in the container, so a guard that only
+looks at the clicked element misses it. Check the closest wrapper too.
+
 **Suppressing a block is not the same as idling it.**
 Setting `autoTrollThreshold` to a huge value to observe "idle ticks" made the
 precondition fail, so the block was skipped entirely (1 start in 90s instead of

--- a/docs/reference/opponent-aware-team-concept.md
+++ b/docs/reference/opponent-aware-team-concept.md
@@ -1,0 +1,242 @@
+---
+title: "Concept: a team built for the opponents that are left"
+status: draft for decision
+last-verified: 2026-09-12
+concerns: "TeamModule (edit-team buttons), LeagueHelper (opponent list), TeamEvaluationService"
+---
+
+# Concept: a team built for the opponents that are left
+
+A draft for decision. It proposes a third button next to *Current Best* and
+*Best Possible* on the edit-team page, and it carries the measurements that say
+what that button would be worth.
+
+The two existing buttons answer one question: which seven girls are strongest.
+Neither of them has ever seen an opponent. This one would rank the same
+candidate teams by the points they are expected to score against the opponents
+this account still has to fight.
+
+## 1. What the two buttons optimise today
+
+`TeamModule.setTopTeam(mode)` builds candidates with `TeamBuilderService` and,
+for mode 1, lets the game calculate each candidate's real stats and picks the
+one with the highest *effective power*
+(`TeamEvaluationService.computeEffectivePower`):
+
+    damage x expectedHit x (1 + sun) x ego x (1 + water)
+
+That is a single number describing a team in isolation. It cannot express that
+140 of the remaining fights are against a water theme, or that an opponent with
+45,809 defence makes 3 % more damage worth nothing while 50 % more would flip
+the fight.
+
+## 2. The objective the third button would use
+
+Not power -- points. The point formulas are measured
+(`bdsm-battle-simulator.md`, section "The point distribution"):
+
+    win  = min(25, 15 + ceil(10 * ownEgoLeft / ownEgoMax))
+    loss = max(3,   3 + ceil(10 * damageDealt / opponentEgoMax))
+
+A loss is worth 3 to 13 points, a win 16 to 25. Both terms reward the same
+thing -- ending the fight with more of your own ego, or taking more of theirs --
+so one function covers won and lost fights:
+
+    score(team) = sum over remaining fights of expectedPoints(team, opponent)
+
+Each remaining opponent enters with its **number of open fights** as a weight,
+not with weight 1. That is the part the request asks for: opponents already
+fought three times contribute nothing, and in the extreme the sum runs over a
+single opponent.
+
+## 3. Who counts as a remaining opponent
+
+`LeagueHelper.numberOfFightAvailable` reads `opponent.match_history[<the
+opponent's id_fighter>]` and counts the `null` entries. Three slots per
+opponent.
+
+Measured on the test account, 2026-09-12, mid league week:
+
+| | |
+|---|---|
+| opponents in `opponents_list` | 180 |
+| rows on the league page | 180 |
+| rows carrying a fight link | 153 |
+| `can_fight === true` | 153 |
+| open fights (sum of `null` slots) | 453 |
+
+The three ways of asking "can I still fight them" agree exactly: 153 opponents
+have a fight link *and* open slots, 0 have a link without slots, 0 have slots
+without a link. Either signal is a correct filter; `match_history` is the one
+that also says *how many* fights are left, which the weighting needs.
+
+## 4. Why the existing cache cannot carry this
+
+`Temp_LeagueOpponentList` exists, and `LeagueHelper._getTempLeagueOpponentList`
+expires it after `LeagueListExpirationSecs` (2 minutes). It is the wrong
+container for two reasons:
+
+- **It holds the wrong fields.** A stored `LeagueOpponent` is
+  `{opponent_id, nickname, power, simuPoints, simu}` -- a simulation result
+  against the team that was fielded when the page was read. The new button needs
+  the opponent's raw stats, because it scores *different* teams against them.
+- **It is only written in one sort mode.** The list is filled inside
+  `getLeagueOpponentListData` behind `usePowerCalc`, i.e. only when the user has
+  chosen the power-calculation sort order.
+
+So: a separate snapshot, written whenever the league page is read, independent
+of the sort mode.
+
+## 5. The snapshot
+
+Everything the scoring needs, per remaining opponent:
+
+| field | source |
+|---|---|
+| id | `player.id_fighter` |
+| damage, defense, remaining_ego, chance | `player.*` |
+| theme elements | `player.team.theme_elements[].type` (the type string only) |
+| open fights | count of `null` in `match_history[id_fighter]` |
+
+Measured sizes for the 153 remaining opponents of the account above:
+
+| form | bytes |
+|---|---|
+| `opponents_list` as it stands | 2,863,641 |
+| stripped to the fields the scoring reads, all 180 opponents | 865,448 |
+| the table above, remaining opponents only | **10,304** (67 per opponent) |
+
+The 865 KB version is still large because every `theme_elements` and
+`synergies` entry repeats the full element object, icon URL included. Keeping
+only the type strings is what brings it to 10 KB, and 10 KB is a size this
+storage can hold -- which matters, because `cleanLogsInStorage` deletes
+`Temp_LeagueOpponentList` first when storage runs out.
+
+**Lifetime.** The 2-minute expiry of the existing list exists so that a fight
+decision is never made on stale opponent data. The snapshot has a different job:
+the edit-team page is reached *after* leaving the league page, so by definition
+the data is a few minutes old there, and refusing to work would make the button
+useless. Proposed: keep the snapshot for the league week, stamp it with the time
+it was read, and show that age on the button's result. A snapshot older than the
+current league gets dropped, as the league reset already does for
+`Temp_LeagueOpponentList` (`StartService`, `HHStoredVars`).
+
+## 6. What the ranking would decide today
+
+The candidates `TeamBuilderService` already builds differ mainly in how many
+girls of one element they stack, i.e. in the team theme. The game calculated
+their real stats (`team_calculate_caracs`, 2026-09-12):
+
+| stack | damage | ego | defense |
+|---|---|---|---|
+| strongest 7 (happens to be water) | 19,879 | 127,004 | 7,295 |
+| 3x sun | 19,759 (-0.6 %) | 122,547 (-3.5 %) | 7,255 |
+| 3x water | 19,879 (+-0) | 127,004 | 7,295 |
+| 3x nature | 19,691 (-0.9 %) | 129,104 (+1.6 %) | 7,211 |
+
+So a theme costs under 1 % of damage. Element domination is worth +10 % on ego
+and attack (measured, `bdsm-battle-simulator.md`). The remaining fights are
+distributed like this:
+
+| opponent theme | open fights |
+|---|---|
+| none | 221 |
+| water | 125 (+6 as sun+water, +9 as nature+water) |
+| nature | 33 |
+| sun | 15 |
+| psychic | 15 |
+| fire | 14 |
+| light | 9 |
+| darkness / stone | 3 each |
+
+The fielded team is water: it dominates fire (14 fights) and is dominated by sun
+(21). A sun team dominates water (140 fights) and is dominated by stone (3).
+Scoring both over the 453 remaining fights with the formulas of section 2:
+
+| theme | points | wins | domination for / against |
+|---|---|---|---|
+| water (fielded) | 5,539 | 172 | 14 / 21 |
+| **sun** | **5,603** | **175** | 140 / 3 |
+| nature | 5,535 | 172 | 3 / 14 |
+
+A switch to sun is worth **+64 points and 3 wins**, or 1.2 %. That is the
+honest size of this button on this account today. It is not nothing, and it is
+the number that should get larger late in the week, when the opponents that are
+left are the ones that were skipped for being too strong -- which is exactly
+what the request wants to test.
+
+## 7. The larger lever sits elsewhere
+
+The same model, run against stat changes instead of themes:
+
+| change | points | wins |
+|---|---|---|
+| baseline (sun) | 5,603 | 175 |
+| +10 % damage | 5,770 (+167) | 181 |
+| +10 % ego | 5,669 (+66) | 178 |
+| +10 % defence | 5,654 (+51) | 178 |
+| +10 % on everything | 5,924 (+321) | 193 |
+| double damage | 6,908 (+1,305) | 237 |
+
+And the same 453 fights sorted by the points each one delivers:
+
+| fights taken | points | per fight |
+|---|---|---|
+| the best 41 (one day of challenges) | 1,025 | 25.0 |
+| the best 100 | 2,496 | 25.0 |
+| the best 287 | 4,939 | 17.2 |
+| all 453 | 5,603 | 12.4 |
+
+Choosing *which* opponent to fight is worth twice as much per fight as any team
+change available here. HHauto already sorts by simulated points in the
+power-calculation sort mode; the third button does not compete with that, it
+adds to it. Whoever expects the button to change the ranking of the week will be
+disappointed; whoever wants the last few percent, and a measurement of when a
+theme switch starts to pay, gets it.
+
+## 8. What has to follow a change of theme
+
+Equipment resonance is bound to the team theme
+(`equipment-resonance.md`, section 5: team first, items after).
+`applyTeamResult` already writes the theme to `TK.teamTheme` for the gear
+optimiser. A third mode has to do the same, and the button's own text has to say
+that the gear run belongs after it -- as the numbered order of the existing
+buttons does (1 Unequip All, 2a/2b pick, 3 Stuff Team).
+
+## 9. What the scoring model does not cover
+
+Stated, because the numbers above were produced with exactly these gaps:
+
+- **Criticals and heal-on-hit.** The league list's `player` object carries
+  `id_fighter, remaining_ego, damage, defense, chance, percent_remaining_ego,
+  level, class, current_season_mojo` -- no crit damage, no heal. Both exist in
+  `player.team.synergies` as `bonus_identifier` with a multiplier, so the
+  snapshot can carry them at about 80 more bytes per opponent. The numbers in
+  sections 6 and 7 were computed without them: no criticals, no healing, damage
+  = attack - defence.
+- **Maximum ego.** Only `remaining_ego` is delivered; the model uses it as the
+  maximum, as the shipped simulator does.
+- **Who strikes first.** Assumed: we do.
+- **The equipped mythic booster.** Known gap of the simulator, measured at
+  +15 % and not modelled (`bdsm-battle-simulator.md`).
+
+None of these gaps favour one theme over another, so the comparison in section 6
+survives them. The absolute point totals do not -- they are a lower bound.
+
+## 10. Open decisions
+
+1. **Button or mode?** `setTopTeam(mode)` takes a `ScoringMode` of 1 or 2 that
+   runs through `TeamBuilderService`, `TeamResult` and the info box. The third
+   button is not a third way of scoring *girls* -- it re-ranks the candidates
+   the existing modes produce. Cleanest is a separate entry point that takes the
+   pool (current or possible) as its argument, so both existing pools stay
+   reachable, as the request asks.
+2. **Which pool does it use?** The request says both, via the two existing
+   buttons. That means the third button needs a pool selector, or it runs twice
+   and reports both.
+3. **What does it do when the snapshot is missing?** Proposed: say so and do
+   nothing, rather than silently falling back to *Current Best* -- a button that
+   sometimes optimises something else is worse than one that refuses.
+4. **Does it field the team, or only report?** For the test the request
+   describes, reporting the delta ("sun: +64 points over 453 remaining fights,
+   3 more wins") is the more useful half, and fielding is one more click.


### PR DESCRIPTION
Documentation only. No source change, no build change.

## The battle model, held against real fights

`docs/reference/bdsm-battle-simulator.md` was checked against two league
fights on the test account. Damage, criticals, heal-on-hit and the point
formulas match the game exactly; the win formula reproduced the awarded
points. Two gaps are now written down instead of implied: the equipped
mythic booster (measured at +15 %, not modelled) and a defence reduction
that is counted twice. Element domination was measured at +10 % on ego and
attack.

## The game surface, re-clicked

`docs/reference/game-surface-inventory.md` carried the claim that none of
the 303 recorded clicks cost a koban. That was wrong -- the Restock control
does, and the tour paid for it twice before the harness learned to see the
price in the surrounding container. The row is relabelled and the re-check
is recorded. Three traps the tour itself fell into went into
`live-verification-lessons.md`: a logged-out placeholder hero that looks
like a falling balance, a click leaving for a foreign domain, and index
drift after a re-render.

## Concept: a team built for the opponents that are left

`docs/reference/opponent-aware-team-concept.md` is a draft for decision, not
an implementation. It proposes a third edit-team button that ranks the
candidate teams by expected league points against the opponents that still
have open fight slots, and it carries the measurements that say what such a
button is worth:

- fight link, `can_fight` and the `null` slots in `match_history` agree on
  all remaining opponents -- the filter is unambiguous
- the snapshot the scoring needs is 10 KB, against 2.9 MB of raw list; the
  existing `Temp_LeagueOpponentList` cannot carry it, because it stores a
  simulation result rather than opponent stats, and only in one sort mode
- a team theme costs under 1 % of damage (`team_calculate_caracs`), while
  domination is worth 10 %
- on the test account today the best theme switch is worth 1.2 % more
  points, while choosing which opponents to fight is worth twice as much per
  fight

The open decisions are listed at the end of the document.