### PR TITLE
chore(hooks): strip tool attribution from commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,4 +1,33 @@
 #!/bin/sh
 # Die Commit-Nachricht ist der zweite Weg nach draußen -- sie steht im Repo und
 # in jedem Klon, und die Datei-Prüfung sieht sie nicht.
-node scripts/check-player-data.mjs --message "$1" || exit 1
+#
+# Zwei Dinge dürfen nicht durch:
+#
+#   1. Eine echte Spielerkennung. Die Prüfung dafür steht unten und bricht ab.
+#   2. Eine Attribution-Zeile eines KI-Werkzeugs. Die wird stillschweigend
+#      gestrichen statt den Commit abzubrechen -- sie ist kein Fehler des
+#      Autors, sondern eine Vorgabe der Umgebung, die hier nicht gilt. Drei
+#      solcher Zeilen haben es schon auf Branches geschafft und mussten per
+#      filter-branch mit Force-Push wieder heraus; eine davon lag auf main und
+#      war nicht mehr zu entfernen. Der Schalter includeCoAuthoredBy in den
+#      Werkzeug-Einstellungen tut dasselbe, aber nur auf einem Rechner und nur
+#      solange ihn niemand zurücksetzt. Dies hier ist die Stelle, die das Repo
+#      selbst mitbringt.
+#
+# Die eigene Co-Authored-By-Zeile eines Menschen bleibt stehen: gestrichen wird
+# nur, was auf Claude, Anthropic, Copilot oder "Generated with" zeigt.
+
+msg="$1"
+muster='^[Cc]o-[Aa]uthored-[Bb]y:.*\(laude\|nthropic\|opilot\|GPT\|noreply@openai\)\|Generated with .*\(Claude\|Copilot\|ChatGPT\)\|🤖'
+
+if grep -q "$muster" "$msg"; then
+    tmp="$msg.hhauto"
+    grep -v "$muster" "$msg" > "$tmp" || :
+    # Leerzeilen, die durch das Streichen am Ende übrig bleiben, mitnehmen.
+    sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$tmp" > "$msg"
+    rm -f "$tmp"
+    echo "commit-msg: Attribution-Zeile entfernt (siehe .githooks/commit-msg)." >&2
+fi
+
+node scripts/check-player-data.mjs --message "$msg" || exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Two questions decide it: does somebody need this to **use** the script, or to
 | `.github/` | the issue templates users fill in, and the workflows that run the gates |
 | `src/`, `spec/`, `build/`, the config files at the root | the source, its tests, and what turns them into the delivery |
 | `scripts/` | the gates, plus the live-check and catalogue tools a contributor measures with |
-| `.githooks/` | the pre-commit hook that stops player data before it reaches GitHub |
+| `.githooks/` | the hooks that stop player data and tool attribution before they reach GitHub |
 | `docs/decisions/` | why the architecture is what it is, and what was rejected |
 | `docs/reference/` | what has been measured about the game, and where the code reads it |
 | `screenshots/` | the source images the wiki serves |
@@ -121,6 +121,16 @@ before anything reaches GitHub. Set the hook up once on a fresh clone:
 ```
 npm run hooks:install    # sets core.hooksPath to .githooks
 ```
+
+Two hooks come with the repository. `pre-commit` refuses a commit whose staged
+files carry a real player identifier. `commit-msg` runs the same check on the
+message, and it also strips attribution lines of AI tools -- a
+`Co-Authored-By:` naming Claude, Anthropic, Copilot or ChatGPT, and a
+"Generated with ..." footer. Those are removed rather than refused, because
+they come from a tool's defaults and not from the author; a human
+`Co-Authored-By:` line stays. Three such lines have already reached branches
+here and had to be taken out with `filter-branch` and a force push, one of
+them from `main`, where it could not be removed at all.
 
 `check:player-data` checks the **shape** such data arrives in: the person keys
 of the game JSON with a number after them, a name field with a value, and in


### PR DESCRIPTION
The `commit-msg` hook already checked the message for player identifiers. It
now also removes attribution lines that AI tools add by default:

- a `Co-Authored-By:` line naming Claude, Anthropic, Copilot or ChatGPT
- a "Generated with ..." footer, robot emoji included

A human `Co-Authored-By:` line stays.

Removed rather than refused, because such a line comes from a tool's
defaults and not from the author -- refusing would only make the author fix
what a tool wrote. Three of them have reached branches in this repository
and had to be taken out with `filter-branch` and a force push; one sat on
`main`, which has force-push protection, so it could not be removed at all.
A per-machine setting does the same thing, but only on that machine and only
until someone resets it. This is the copy the repository carries itself.

Checked before committing, on a message holding all three forms at once: the
tool lines and the footer went, the human co-author line stayed, and the
blank lines left behind by the removal were cleaned up.

`CONTRIBUTING.md` describes both hooks now, and the file table no longer
names only `pre-commit`.